### PR TITLE
Better build documentation, minor build fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,17 +2,24 @@
 
 These instructions explain how to set up an environment for building Gambatte-Speedrun from source on different operating systems. Once you've set up your build environment, see the main [README.md](README.md) for build instructions and information on running the test suite.
 
+If all you want to do is build Gambatte-Speedrun's `libgambatte` shared library (for use in scripting, TASing, and other programmatic use of the emulation core), you do not need to perform the Qt-specific steps or the Testrunner-specific steps. The steps listed before the sections with specific steps are still required.
+
+Running the hwtests suite requires installing an additional dependency (`libpng`); this can be skipped if you have no intention of using the testrunner (we primarily use the test suite to confirm no regressions in accuracy were introduced in our changes). Likewise, the Qt-specific steps can be skipped if you have no intention of building the full Qt UI application.
+
 ## Windows
 
 ***\*NOTE:*** The instructions below assume you're installing 64-bit MSYS2 and using the 32-bit MinGW toolchain (they do work with other configurations, but the commands won't be exactly the same).
 * Choice of 32-bit vs 64-bit for MSYS2 doesn't really matter; either is fine
-* There's currently no benefit to building a 64-bit version of Gambatte-Speedrun on Windows, and you'd need to grab some extra 64-bit packages; thus 32-bit is used for the release binaries
+* There's currently no benefit to building a 64-bit version of Gambatte-Speedrun on Windows, so 32-bit is used for the release binaries
 
-Do the following steps:
+At the end of these steps, to do any build tasks related to Gambatte-Speedrun, open the MSYS2 MinGW 32-bit shell (under the MSYS2 folder in the Start menu; ***\*must be\**** this specific shell in order for building to work).
 
-(1) Install [MSYS2](https://www.msys2.org/) by selecting the one-click installer exe for x86_64
+\
+Do the following: 
 
-(2) Initial setup of MSYS2 (copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))
+\- Install [MSYS2](https://www.msys2.org/) by selecting the one-click installer exe for x86_64
+
+\- Initial setup of MSYS2 (copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))
 ```
 Run MSYS2 shell (Command Prompt). C:\msys64\msys2_shell.cmd
 
@@ -24,7 +31,7 @@ Follow the instructions. Repeat this step until it says there are no packages to
 
 See the above link if you have an older installation of MSYS2 and/or pacman.
 ```
-(3) Prepare MSYS2 for Qt related build development environment (copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))
+\- Prepare MSYS2 for Qt related build development environment (copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))
 ```
 Start MSYS2-shell. Run/execute below commands to load MinGW-w64 SEH (64bit/x86_64) posix and Dwarf-2
 (32bit/i686) posix toolchains & related other tools, dependencies & components from MSYS2 REPO
@@ -38,47 +45,88 @@ location, and, x86_64(64bit) toolchain loads into /c/msys64/mingw64/bin (C:\msys
 directory. Perl, Ruby, Python, OpenSSL etc loads into /c/msys64/usr/bin (C:\msys64\usr\bin)
 directory.
 ```
-(4) Acquire and install Qt 5.6 (static library environment). *(NOTE: newer versions bundle a lot more into the static environment and create much larger builds.*)
+\- Install the `zlib` package:
+```
+$ pacman -S mingw-w64-i686-zlib
+```
+
+### Qt-specific steps
+
+\- Acquire and install the Qt 5.6 static library environment *(NOTE: newer versions bundle a lot more into the environment and create much larger builds*)
 ```
 $ curl -O http://repo.msys2.org/mingw/i686/mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
 $ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
 ```
-(5) Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6
+\- Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6
 ```
-$ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-libpng mingw-w64-i686-dbus
+$ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-dbus
 ```
-(6) Modify .bash_profile (in /c/msys64/home/{USERNAME}) add this line to the end of the file:
+\- Modify .bash_profile (in /c/msys64/home/\<USERNAME\>) add this line to the end of the file:
 ```
 PATH="/mingw32/qt5-static/bin:${PATH}"
 ```
-(7) Open MSYS2 MinGW 32-bit (***\*must be\**** this specific shell) for building Gambatte-Speedrun (under the MSYS2 folder in the Start menu)
+
+### Testrunner-specific steps
+
+\- Install the `libpng` package:
+```
+$ pacman -S mingw-w64-i686-libpng
+```
 
 ## macOS
 
-The easiest way to build with Qt5 on macOS is through the [Homebrew](https://brew.sh/) package manager. You will also need to have the Xcode Command Line Tools installed. 
+Open the macOS Terminal and do the following:
 
-Open a macOS Terminal and do the following:
-
-(1) Install Homebrew if not already installed (copied from [here](https://brew.sh/))
+\- Install Homebrew if not already installed (copied from [here](https://brew.sh/)):
 ```
 $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
-(2) Install Qt5 package through Homebrew *(NOTE: currently tested to work with XCode 11 and Qt 5.14.1, which supports macOS 10.13+; builds for older macOS versions should also be possible, but you would need to dig up the Homebrew formulae for older versions of Qt5)*
+\- Install the `scons` and `zlib` packages:
+```
+$ brew install scons zlib
+```
+
+### Qt-specific steps
+
+\- Install Xcode Command Line Tools if not already installed:
+```
+$ xcode-select --install
+```
+\- Install Qt5 package through Homebrew *(NOTE: currently tested to work with XCode 11 and Qt 5.14.1, which supports macOS 10.13+; builds for older macOS versions should also be possible, but you would need to dig up the Homebrew formulae for older versions of Qt5)*
 ```
 $ brew install qt
-```
-(3) Install the `scons` package, which is needed for the build process
-```
-$ brew install scons
 ```
 ***\*NOTE:*** After building and creating "Gambatte Qt.app", you can run the following command to create a deployable standalone macOS app, which can be used as a release build that other macOS users can run:
 ```
 $ macdeployqt gambatte_qt/bin/Gambatte\ Qt.app -dmg
 ```
+
+### Testrunner-specific steps
+
+\- Install the `libpng` package:
+```
+$ brew install libpng
+```
+
 ## Debian
 
-To build on Debian, run the following to install dependencies:
+Open a terminal and do the following:
+
+\- Install build dependencies:
 ```
-$ sudo apt install build-essential git scons zlib1g-dev qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
+$ sudo apt install build-essential git scons zlib1g-dev 
 ```
-Otherwise GLHF.
+
+### Qt-specific steps
+
+\- Install qt5 development packages:
+```
+$ sudo apt install qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
+```
+
+### Testrunner-specific steps
+
+\- Install the `libpng-dev` package:
+```
+$ sudo apt install libpng-dev
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,84 @@
+# Setting up the build environment
+
+These instructions explain how to set up an environment for building Gambatte-Speedrun from source on different operating systems. Once you've set up your build environment, see the main [README.md](README.md) for build instructions and information on running the test suite.
+
+## Windows
+
+***\*NOTE:*** The instructions below assume you're installing 64-bit MSYS2 and using the 32-bit MinGW toolchain (they do work with other configurations, but the commands won't be exactly the same).
+* Choice of 32-bit vs 64-bit for MSYS2 doesn't really matter; either is fine
+* There's currently no benefit to building a 64-bit version of Gambatte-Speedrun on Windows, and you'd need to grab some extra 64-bit packages; thus 32-bit is used for the release binaries
+
+Do the following steps:
+
+(1) Install [MSYS2](https://www.msys2.org/) by selecting the one-click installer exe for x86_64
+
+(2) Initial setup of MSYS2 (copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))
+```
+Run MSYS2 shell (Command Prompt). C:\msys64\msys2_shell.cmd
+
+Update msys2 core components and packages (if you have not done so yet):
+
+$ pacman -Syuu
+
+Follow the instructions. Repeat this step until it says there are no packages to update.
+
+See the above link if you have an older installation of MSYS2 and/or pacman.
+```
+(3) Prepare MSYS2 for Qt related build development environment (copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))
+```
+Start MSYS2-shell. Run/execute below commands to load MinGW-w64 SEH (64bit/x86_64) posix and Dwarf-2
+(32bit/i686) posix toolchains & related other tools, dependencies & components from MSYS2 REPO
+(MINGW-packages, MSYS2-packages):
+
+$ pacman -S base-devel git mercurial cvs wget p7zip
+$ pacman -S perl ruby python2 mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
+
+Note: the i686 (32bit) toolchain loads into /c/msys64/mingw32/bin (C:\msys64\mingw32\bin) directory
+location, and, x86_64(64bit) toolchain loads into /c/msys64/mingw64/bin (C:\msys64\mingw64\bin)
+directory. Perl, Ruby, Python, OpenSSL etc loads into /c/msys64/usr/bin (C:\msys64\usr\bin)
+directory.
+```
+(4) Acquire and install Qt 5.6 (static library environment). *(NOTE: newer versions bundle a lot more into the static environment and create much larger builds.*)
+```
+$ curl -O http://repo.msys2.org/mingw/i686/mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
+$ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
+```
+(5) Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6
+```
+$ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-libpng mingw-w64-i686-dbus
+```
+(6) Modify .bash_profile (in /c/msys64/home/{USERNAME}) add this line to the end of the file:
+```
+PATH="/mingw32/qt5-static/bin:${PATH}"
+```
+(7) Open MSYS2 MinGW 32-bit (***\*must be\**** this specific shell) for building Gambatte-Speedrun (under the MSYS2 folder in the Start menu)
+
+## macOS
+
+The easiest way to build with Qt5 on macOS is through the [Homebrew](https://brew.sh/) package manager. You will also need to have the Xcode Command Line Tools installed. 
+
+Open a macOS Terminal and do the following:
+
+(1) Install Homebrew if not already installed (copied from [here](https://brew.sh/))
+```
+$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+(2) Install Qt5 package through Homebrew *(NOTE: currently tested to work with XCode 11 and Qt 5.14.1, which supports macOS 10.13+; builds for older macOS versions should also be possible, but you would need to dig up the Homebrew formulae for older versions of Qt5)*
+```
+$ brew install qt
+```
+(3) Install the `scons` package, which is needed for the build process
+```
+$ brew install scons
+```
+***\*NOTE:*** After building and creating "Gambatte Qt.app", you can run the following command to create a deployable standalone macOS app, which can be used as a release build that other macOS users can run:
+```
+$ macdeployqt gambatte_qt/bin/Gambatte\ Qt.app -dmg
+```
+## Debian
+
+To build on Debian, run the following to install dependencies:
+```
+$ sudo apt install build-essential git scons zlib1g-dev qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
+```
+Otherwise GLHF.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,14 +12,14 @@ Running the hwtests suite requires installing an additional dependency (`libpng`
 * Choice of 32-bit vs 64-bit for MSYS2 doesn't really matter; either is fine
 * There's currently no benefit to building a 64-bit version of Gambatte-Speedrun on Windows, so 32-bit is used for the release binaries
 
-At the end of these steps, to do any build tasks related to Gambatte-Speedrun, open the MSYS2 MinGW 32-bit shell (under the MSYS2 folder in the Start menu; ***\*must be\**** this specific shell in order for building to work).
+***\*NOTE:*** At the end of these steps, to do any build tasks related to Gambatte-Speedrun, open the MSYS2 MinGW 32-bit shell (under the MSYS2 folder in the Start menu; ***\*must be\**** this specific shell in order for building to work).
 
 \
 Do the following: 
 
 \- Install [MSYS2](https://www.msys2.org/) by selecting the one-click installer exe for x86_64
 
-\- Initial setup of MSYS2 (copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))
+\- Initial setup of MSYS2 *(copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))*:
 ```
 Run MSYS2 shell (Command Prompt). C:\msys64\msys2_shell.cmd
 
@@ -31,7 +31,7 @@ Follow the instructions. Repeat this step until it says there are no packages to
 
 See the above link if you have an older installation of MSYS2 and/or pacman.
 ```
-\- Prepare MSYS2 for Qt related build development environment (copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))
+\- Prepare MSYS2 for general build development environment *(including essential packages for Qt-related building; copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))*:
 ```
 Start MSYS2-shell. Run/execute below commands to load MinGW-w64 SEH (64bit/x86_64) posix and Dwarf-2
 (32bit/i686) posix toolchains & related other tools, dependencies & components from MSYS2 REPO
@@ -52,16 +52,16 @@ $ pacman -S mingw-w64-i686-zlib
 
 ### Qt-specific steps
 
-\- Acquire and install the Qt 5.6 static library environment *(NOTE: newer versions bundle a lot more into the environment and create much larger builds*)
+\- Acquire and install the Qt 5.6 static library environment *(NOTE: newer versions bundle a lot more into the environment and create much larger builds)*:
 ```
 $ curl -O http://repo.msys2.org/mingw/i686/mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
 $ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
 ```
-\- Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6
+\- Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6:
 ```
 $ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-dbus
 ```
-\- Modify .bash_profile (in /c/msys64/home/\<USERNAME\>) add this line to the end of the file:
+\- Modify .bash_profile *(in /c/msys64/home/\<USERNAME\>)* by adding this line to the end of the file:
 ```
 PATH="/mingw32/qt5-static/bin:${PATH}"
 ```
@@ -75,9 +75,9 @@ $ pacman -S mingw-w64-i686-libpng
 
 ## macOS
 
-Open the macOS Terminal and do the following:
+Open a terminal and do the following:
 
-\- Install Homebrew if not already installed (copied from [here](https://brew.sh/)):
+\- Install Homebrew if not already installed *(copied from [here](https://brew.sh/))*:
 ```
 $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
@@ -92,7 +92,7 @@ $ brew install scons zlib
 ```
 $ xcode-select --install
 ```
-\- Install Qt5 package through Homebrew *(NOTE: currently tested to work with XCode 11 and Qt 5.14.1, which supports macOS 10.13+; builds for older macOS versions should also be possible, but you would need to dig up the Homebrew formulae for older versions of Qt5)*
+\- Install Qt5 package through Homebrew *(NOTE: currently tested to work with XCode 11 and Qt 5.14.1, which supports macOS 10.13+; builds for older macOS versions should also be possible, but you would need to dig up the Homebrew formulae for older versions of Qt5)*:
 ```
 $ brew install qt
 ```
@@ -108,7 +108,7 @@ $ macdeployqt gambatte_qt/bin/Gambatte\ Qt.app -dmg
 $ brew install libpng
 ```
 
-## Debian
+## Debian/Ubuntu
 
 Open a terminal and do the following:
 
@@ -119,7 +119,7 @@ $ sudo apt install build-essential git scons zlib1g-dev
 
 ### Qt-specific steps
 
-\- Install qt5 development packages:
+\- Install Qt5 development packages, plus Gambatte-Speedrun dependencies that aren't bundled with Qt5:
 ```
 $ sudo apt install qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ Gambatte-Speedrun has been updated to build using Qt5 instead of Qt4. Distributa
 
 ## Building
 
-See [INSTALL.md](INSTALL.md) for how to set up the build environment. After completing the setup, running the following in the project's root directory should build the "PSR" version of Gambatte-Speedrun:
+See [INSTALL.md](INSTALL.md) for how to set up the build environment. The amount of setup you need to do depends on exactly what you are planning to build and use.
+
+### Shared Library
+
+If you only wish to build Gambatte-Speedrun's `libgambatte` shared library (for use in scripting, TASing, and other programmatic use of the emulation core), and have the basic build environment set up, you can run the following from the project's root directory, regardless of platform:
+```
+$ sh scripts/build_shlib.sh
+```
+
+### Gambatte-Speedrun *(i.e. the full-blown emulator)*
+
+After completing all the Qt-specific build steps in [INSTALL.md](INSTALL.md), running the following in the project's root directory should build the "PSR" version of Gambatte-Speedrun:
 ```
 $ sh scripts/build_qt.sh
 ```
@@ -19,16 +30,14 @@ DEFINES += SHOW_PLATFORM_GBC
 DEFINES += SHOW_PLATFORM_GBA
 DEFINES += SHOW_PLATFORM_SGB
 ```
-To build Gambatte-Speedrun's `libgambatte` (shared library; for use in scripting, TASing, and other programmatic use of the core emulator), you can run the following from the project root, regardless of platform:
-```
-$ sh scripts/build_shlib.sh
-```
-## Running Tests
+
+### Testrunner
 
 To be able to run the upstream hwtests suite on Gambatte-Speedrun, you must acquire the DMG and CGB bootroms. Name the DMG bootrom `bios.gb`, the CGB bootrom `bios.gbc`, and move both into the `test` directory.
 
-Run the following in a terminal from the project root to assemble and run all hwtests:
+Run the following in a terminal from the project's root directory to assemble and run all hwtests:
 ```
 $ (cd test && sh scripts/assemble_tests.sh)
 $ sh scripts/test.sh
 ```
+Note that the first line (with `assemble_tests.sh`) only needs to be run one time, or until the contents of the hwtests directory change.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
-# gambatte-speedrun
+# Gambatte-Speedrun
 
 Fork of https://github.com/sinamas/gambatte with changes related to Pokemon speedrunning. Under GPLv2.
 
-This has been updated to build using Qt5 instead of Qt4. If you have Qt5 dependencies, building should be easy enough. It can be built on windows using [msys2](https://msys2.github.io/) and the qt5-static package.
+Gambatte-Speedrun has been updated to build using Qt5 instead of Qt4. Distributable binaries can be built on Windows using [msys2](https://msys2.github.io/) and the qt5-static package, or on macOS using [Homebrew](https://brew.sh/) and the qt5 package with its `macdeployqt` tool.
 
-To build it on Debian, do:
+## Building
 
-    sudo apt install build-essential git scons zlib1g-dev qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
-    git clone https://github.com/Dabomstew/gambatte-speedrun
-    cd gambatte-speedrun
-    sh scripts/build_qt.sh
-    cp gambatte_qt/bin/gambatte_qt SOMEWHERE/gsr # or w/e
-    
-To build the "non-PSR" version with additional selectable platforms (GB, GBC, GBA, SGB2), create `gambatte_qt/src/platforms.pri` with the following:
-    
-    # platform support
-    # GBP is hardcoded
-    DEFINES += SHOW_PLATFORM_GB
-    DEFINES += SHOW_PLATFORM_GBC
-    DEFINES += SHOW_PLATFORM_GBA
-    DEFINES += SHOW_PLATFORM_SGB
+See [INSTALL.md](INSTALL.md) for how to set up the build environment. After completing the setup, running the following in the project's root directory should build the "PSR" version of Gambatte-Speedrun:
+```
+$ sh scripts/build_qt.sh
+```
+To instead build the "non-PSR" version, with additional selectable platforms (GB, GBC, GBA, SGB2), create `gambatte_qt/src/platforms.pri` with the following (before running `build_qt.sh`):
+```
+# platform support
+# GBP is hardcoded
+DEFINES += SHOW_PLATFORM_GB
+DEFINES += SHOW_PLATFORM_GBC
+DEFINES += SHOW_PLATFORM_GBA
+DEFINES += SHOW_PLATFORM_SGB
+```
+To build Gambatte-Speedrun's `libgambatte` (shared library; for use in scripting, TASing, and other programmatic use of the core emulator), you can run the following from the project root, regardless of platform:
+```
+$ sh scripts/build_shlib.sh
+```
+## Running Tests
 
-Otherwise GLHF.
+To be able to run the upstream hwtests suite on Gambatte-Speedrun, you must acquire the DMG and CGB bootroms. Name the DMG bootrom `bios.gb`, the CGB bootrom `bios.gbc`, and move both into the `test` directory.
+
+Run the following in a terminal from the project root to assemble and run all hwtests:
+```
+$ (cd test && sh scripts/assemble_tests.sh)
+$ sh scripts/test.sh
+```

--- a/gambatte_qt/src/src.pro
+++ b/gambatte_qt/src/src.pro
@@ -31,7 +31,7 @@ DESTDIR = ../bin
 INCLUDEPATH += ../../libgambatte/include
 DEPENDPATH  += ../../libgambatte/include
 QT += widgets gui-private
-LIBS += -L../../libgambatte -lgambatte -lz
+LIBS += -L../../libgambatte -l:libgambatte.a -lz
 win32 {
 	LIBS += -lole32
 	#RC_FILE = gambatteicon.rc

--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -73,7 +73,7 @@ if sys.platform == 'darwin':
 
 shlib = env.SharedLibrary('gambatte', sourceFiles + ['src/cinterface.cpp'],
                           CXXFLAGS = env['CXXFLAGS'] + ' -DDLLABLES' + rev(),
-                          LINKFLAGS = env['LINKFLAGS'] + ' -static -s',
+                          LINKFLAGS = env['LINKFLAGS'] + ' -s',
                           LIBS = sys_libs,
                           SHLIBPREFIX = "lib")
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -14,3 +14,9 @@ rm -f *gambatte*/config.log
 
 echo "rm -rf *gambatte*/.scon*"
 rm -rf *gambatte*/.scon*
+
+echo "rm -f test/config.log"
+rm -f test/config.log
+
+echo "rm -rf test/.scon*"
+rm -rf test/.scon*


### PR DESCRIPTION
Added detailed documentation for building on Windows + macOS + Debian/Ubuntu. The second commit includes a few minor functional changes that fixed some incorrect and unintended build behavior:
* building shared library on Linux was broken due to unnecessary `-static` link flag
* building gambatte_qt *after* building the shared library would use the shared libgambatte instead of the static one
* `scripts/clean.sh` was modified to fix potential scons caching issues in the test directory (it does this already, but only in the libgambatte directory)