### PR TITLE
Platform cleanup (fixes DMG-on-CGB)

### DIFF
--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -53,8 +53,8 @@ public:
 		mem_.setOsdElement(osdElement);
 	}
 
-	LoadRes load(std::string const &romfile, bool cgbMode, bool multicartCompat) {
-		return mem_.loadROM(romfile, cgbMode, multicartCompat);
+	LoadRes load(std::string const &romfile, unsigned flags) {
+		return mem_.loadROM(romfile, flags);
 	}
 
 	bool loaded() const { return mem_.loaded(); }
@@ -75,7 +75,6 @@ public:
 	void setGameGenie(std::string const &codes) { mem_.setGameGenie(codes); }
 	void setGameShark(std::string const &codes) { mem_.setGameShark(codes); }
 	void setBios(unsigned char *buffer, std::size_t size) { mem_.setBios(buffer, size); }
-	bool gbIsCgb() { return mem_.gbIsCgb(); }
 
 	unsigned char externalRead(unsigned short addr) {
 		return mem_.read(addr, cycleCounter_);

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -94,8 +94,7 @@ void GB::reset(std::size_t samplesToStall, std::string const &build) {
 		SaveState state;
 		p_->cpu.setStatePtrs(state);
 		p_->cpu.saveState(state);
-		unsigned flags = p_->loadflags;
-		setInitState(state, flags & CGB_MODE, flags & GBA_FLAG, flags & SGB_MODE);
+		setInitState(state, p_->loadflags & CGB_MODE, p_->loadflags & SGB_MODE);
 		p_->cpu.loadState(state);
 
 		if (samplesToStall > 0)
@@ -118,14 +117,13 @@ LoadRes GB::load(std::string const &romfile, unsigned const flags) {
 	if (p_->cpu.loaded() && p_->implicitSave())
 		p_->cpu.saveSavedata();
 
-	LoadRes const loadres = p_->cpu.load(romfile,
-	                                     flags & CGB_MODE,
-	                                     flags & MULTICART_COMPAT);
+	LoadRes const loadres = p_->cpu.load(romfile, flags);
+
 	if (loadres == LOADRES_OK) {
 		SaveState state;
 		p_->cpu.setStatePtrs(state);
 		p_->loadflags = flags;
-		setInitState(state, flags & CGB_MODE, flags & GBA_FLAG, flags & SGB_MODE);
+		setInitState(state, flags & CGB_MODE, flags & SGB_MODE);
 		setInitStateCart(state);
 		p_->cpu.loadState(state);
 		p_->cpu.loadSavedata();

--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -1150,7 +1150,7 @@ static void setInitialDmgIoamhram(unsigned char ioamhram[]) {
 
 } // anon namespace
 
-void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bool const sgb) {
+void gambatte::setInitState(SaveState &state, bool const cgb, bool const sgb) {
 	static unsigned char const cgbObjpDump[0x40] = {
 		0x00, 0x00, 0xF2, 0xAB,
 		0x61, 0xC2, 0xD9, 0xBA,
@@ -1187,8 +1187,6 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 	state.cpu.prefetched = false;
 	state.cpu.skip = false;
 	state.mem.biosMode = true;
-	state.mem.cgbSwitching = false;
-	state.mem.agbFlag = cgb && agb;
 
 	setInitialVram(state.mem.vram.ptr, cgb);
 
@@ -1225,8 +1223,6 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 	state.mem.enableRam = false;
 	state.mem.rambankMode = false;
 	state.mem.hdmaTransfer = false;
-	state.mem.gbIsCgb = cgb;
-	state.mem.gbIsSgb = sgb;
 	state.mem.stopped = false;
 
 
@@ -1300,7 +1296,7 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 	state.ppu.nextM0Irq = 0;
 	state.ppu.oldWy = state.mem.ioamhram.get()[0x14A];
 	state.ppu.pendingLcdstatIrq = false;
-	state.ppu.isCgb = cgb;
+	state.ppu.notCgbDmg = true;
 
 	// spu.cycleCounter >> 12 & 7 represents the frame sequencer position.
 	state.spu.cycleCounter = state.cpu.cycleCounter >> 1;

--- a/libgambatte/src/initstate.h
+++ b/libgambatte/src/initstate.h
@@ -21,7 +21,7 @@
 
 namespace gambatte {
 
-void setInitState(struct SaveState &state, bool cgb, bool agb, bool sgb);
+void setInitState(struct SaveState &state, bool cgb, bool sgb);
 void setInitStateCart(struct SaveState &state);
 
 }

--- a/libgambatte/src/mem/time.cpp
+++ b/libgambatte/src/mem/time.cpp
@@ -56,7 +56,7 @@ void Time::loadState(SaveState const &state) {
 	lastTime_.tv_sec = state.time.lastTimeSec;
 	lastTime_.tv_usec = state.time.lastTimeUsec;
 	lastCycles_ = state.time.lastCycles;
-	ds_ = state.ppu.isCgb & state.mem.ioamhram.get()[0x14D] >> 7;
+	ds_ = state.mem.ioamhram.get()[0x14D] >> 7;
 }
 
 std::time_t Time::get(unsigned long const cc) {

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -58,6 +58,8 @@ public:
 	unsigned long stop(unsigned long cycleCounter, bool &skip);
 	void stall(unsigned long cycleCounter, unsigned long cycles);
 	bool isCgb() const { return lcd_.isCgb(); }
+	bool isCgbDmg() const { return lcd_.isCgbDmg(); }
+	bool isSgb() const { return gbIsSgb_; }
 	bool ime() const { return intreq_.ime(); }
 	bool halted() const { return intreq_.halted(); }
 	unsigned long nextEventTime() const { return intreq_.minEventTime(); }
@@ -111,7 +113,7 @@ public:
 
 	unsigned long event(unsigned long cycleCounter);
 	unsigned long resetCounters(unsigned long cycleCounter);
-	LoadRes loadROM(std::string const &romfile, bool cgbMode, bool multicartCompat);
+	LoadRes loadROM(std::string const &romfile, unsigned flags);
 	void setSaveDir(std::string const &dir) { cart_.setSaveDir(dir); }
 
 	void setInputGetter(InputGetter *getInput, void *p) {
@@ -156,7 +158,6 @@ public:
 		std::memcpy(bios_, buffer, size);
 		biosSize_ = size;
 	}
-	bool gbIsCgb() { return gbIsCgb_; }
 
 	unsigned timeNow(unsigned long const cc) const { return cart_.timeNow(cc); }
 
@@ -190,9 +191,7 @@ private:
 	unsigned char serialCnt_;
 	bool blanklcd_;
 	bool biosMode_;
-	bool cgbSwitching_;
 	bool agbFlag_;
-	bool gbIsCgb_;
 	bool gbIsSgb_;
 	bool stopped_;
 	enum HdmaState { hdma_low, hdma_high, hdma_requested } haltHdmaState_;

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -35,7 +35,7 @@ struct SaveState {
 		void set(T *p, std::size_t size) { ptr = p; size_ = size; }
 
 		friend class SaverList;
-		friend void setInitState(SaveState &, bool, bool, bool);
+		friend void setInitState(SaveState &, bool, bool);
 		friend void setInitStateCart(SaveState &);
 
 	private:
@@ -85,10 +85,6 @@ struct SaveState {
 		unsigned char /*bool*/ rambankMode;
 		unsigned char /*bool*/ hdmaTransfer;
 		unsigned char /*bool*/ biosMode;
-		unsigned char /*bool*/ cgbSwitching;
-		unsigned char /*bool*/ agbFlag;
-		unsigned char /*bool*/ gbIsCgb;
-		unsigned char /*bool*/ gbIsSgb;
 		unsigned char /*bool*/ stopped;
 
 		struct SGB {
@@ -141,7 +137,7 @@ struct SaveState {
 		unsigned char wscx;
 		unsigned char /*bool*/ weMaster;
 		unsigned char /*bool*/ pendingLcdstatIrq;
-		unsigned char /*bool*/ isCgb;
+		unsigned char /*bool*/ notCgbDmg;
 	} ppu;
 
 	struct SPU {

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -98,6 +98,7 @@ inline void Channel4::Lfsr::event() {
 void Channel4::Lfsr::nr3Change(unsigned newNr3, unsigned long cc) {
 	updateBackupCounter(cc);
 	nr3_ = newNr3;
+	counter_ = cc;
 }
 
 void Channel4::Lfsr::nr4Init(unsigned long cc) {

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -262,10 +262,6 @@ SaverList::SaverList()
 	{ static char const label[] = { r,a,m,b,m,o,d, NUL }; ADD(mem.rambankMode); }
 	{ static char const label[] = { h,d,m,a,       NUL }; ADD(mem.hdmaTransfer); }
 	{ static char const label[] = { b,i,o,s,       NUL }; ADD(mem.biosMode); }
-	{ static char const label[] = { a,g,b,f,l,a,g, NUL }; ADD(mem.agbFlag); }
-	{ static char const label[] = { c,g,b,s,w,     NUL }; ADD(mem.cgbSwitching); }
-	{ static char const label[] = { b,i,o,s,c,g,b, NUL }; ADD(mem.gbIsCgb); }
-	{ static char const label[] = { i,s,s,g,b,     NUL }; ADD(mem.gbIsSgb); }
 	{ static char const label[] = { s,t,o,p,p,e,d, NUL }; ADD(mem.stopped); }
 	{ static char const label[] = { h,u,c,NO3,r,a,m, NUL }; ADD(mem.HuC3RAMflag); }
 	{ static char const label[] = { s,g,b,s,y,s,   NUL }; ADDPTR(mem.sgb.systemColors); }
@@ -311,7 +307,7 @@ SaverList::SaverList()
 	{ static char const label[] = { w,s,c,x,       NUL }; ADD(ppu.wscx); }
 	{ static char const label[] = { w,e,m,a,s,t,r, NUL }; ADD(ppu.weMaster); }
 	{ static char const label[] = { l,c,d,s,i,r,q, NUL }; ADD(ppu.pendingLcdstatIrq); }
-	{ static char const label[] = { i,s,c,g,b,     NUL }; ADD(ppu.isCgb); }
+	{ static char const label[] = { i,s,c,g,b,     NUL }; ADD(ppu.notCgbDmg); }
 	{ static char const label[] = { s,p,u,c,n,t,r, NUL }; ADD(spu.cycleCounter); }
 	{ static char const label[] = { s,p,u,c,n,t,l, NUL }; ADD(spu.lastUpdate); }
 	{ static char const label[] = { s,w,p,c,n,t,r, NUL }; ADD(spu.ch1.sweep.counter); }

--- a/libgambatte/src/video.cpp
+++ b/libgambatte/src/video.cpp
@@ -143,10 +143,6 @@ void LCD::reset(unsigned char const *oamram, unsigned char const *vram, bool cgb
 	refreshPalettes();
 }
 
-void LCD::setCgb(bool cgb) {
-	ppu_.setCgb(cgb);
-}
-
 void LCD::setStatePtrs(SaveState &state) {
 	state.ppu.dmgColorsBgr15.set(dmgColorsBgr15_, sizeof dmgColorsBgr15_ / sizeof dmgColorsBgr15_[0]);
 	state.ppu.bgpData.set(  bgpData_, sizeof  bgpData_);
@@ -202,7 +198,7 @@ void LCD::loadState(SaveState const &state, unsigned char const *const oamram) {
 }
 
 void LCD::refreshPalettes() {
-	if (ppu_.cgb()) {
+	if (isCgb() && !isCgbDmg()) {
 		for (int i = 0; i < max_num_palettes * num_palette_entries; ++i) {
 			ppu_.bgPalette()[i] = gbcToRgb32( bgpData_[2 * i] |  bgpData_[2 * i + 1] * 0x100l, isTrueColors());
 			ppu_.spPalette()[i] = gbcToRgb32(objpData_[2 * i] | objpData_[2 * i + 1] * 0x100l, isTrueColors());

--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -51,12 +51,12 @@ public:
 	LCD(unsigned char const *oamram, unsigned char const *vram,
 	    VideoInterruptRequester memEventRequester);
 	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb);
+	void setCgbDmg(bool enabled) { ppu_.setCgbDmg(enabled); }
 	void setStatePtrs(SaveState &state);
 	void saveState(SaveState &state) const;
 	void loadState(SaveState const &state, unsigned char const *oamram);
 	void setDmgPaletteColor(unsigned palNum, unsigned colorNum, unsigned long rgb32);
 	void setVideoBuffer(uint_least32_t *videoBuf, std::ptrdiff_t pitch);
-	void setCgb(bool cgb);
 	void copyCgbPalettesToDmg();
 	void setTrueColors(bool trueColors);
 	void setOsdElement(transfer_ptr<OsdElement> osdElement) { osdElement_ = osdElement; }
@@ -146,6 +146,7 @@ public:
 	bool hdmaIsEnabled() const { return eventTimes_(memevent_hdma) != disabled_time; }
 	void update(unsigned long cycleCounter);
 	bool isCgb() const { return ppu_.cgb(); }
+	bool isCgbDmg() const { return ppu_.cgbDmg(); }
 	bool isDoubleSpeed() const { return ppu_.lyCounter().isDoubleSpeed(); }
 	bool isTrueColors() const { return ppu_.trueColors(); }
 	void setSpeedupFlags(unsigned flags) { ppu_.setSpeedupFlags(flags); }

--- a/libgambatte/src/video/ppu.h
+++ b/libgambatte/src/video/ppu.h
@@ -97,6 +97,7 @@ struct PPUPriv {
 	unsigned char endx;
 
 	bool cgb;
+	bool cgbDmg;
 	bool weMaster;
 	bool trueColors;
 	unsigned speedupFlags;
@@ -113,6 +114,7 @@ public:
 
 	unsigned long * bgPalette() { return p_.bgPalette; }
 	bool cgb() const { return p_.cgb; }
+	bool cgbDmg() const { return p_.cgbDmg; }
 	bool trueColors() const { return p_.trueColors; }
 	void doLyCountEvent() { p_.lyCounter.doEvent(); }
 	unsigned long doSpriteMapEvent(unsigned long time) { return p_.spriteMapper.doEvent(time); }
@@ -131,6 +133,7 @@ public:
 	void oamChange(unsigned char const *oamram, unsigned long cc) { p_.spriteMapper.oamChange(oamram, cc); }
 	unsigned long predictedNextXposTime(unsigned xpos) const;
 	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb);
+	void setCgbDmg(bool enabled) { p_.cgbDmg = enabled; }
 	void resetCc(unsigned long oldCc, unsigned long newCc);
 	void saveState(SaveState &ss) const;
 	void setFrameBuf(uint_least32_t *buf, std::ptrdiff_t pitch) { p_.framebuf.setBuf(buf, pitch); }
@@ -144,7 +147,6 @@ public:
 	void speedChange();
 	unsigned long * spPalette() { return p_.spPalette; }
 	void update(unsigned long cc);
-	void setCgb(bool cgb) { p_.cgb = cgb; }
 	void setTrueColors(bool trueColors) { p_.trueColors = trueColors; }
 	void setSpeedupFlags(unsigned flags) { p_.speedupFlags = flags; }
 


### PR DESCRIPTION
Submitting the "Mickey fix" on gifvex's behalf. This fixes two issues (1 major, 1 minor) seen in Mickey's Dangerous Chase testing, while attempting to console-verify a resynced TAS:
* **Major fix:** Use CGB LCD timings for DMG-only games being played on CGB. *(Previous GSR behavior switched the whole LCD to DMG for these games; this didn't matter for Pokémon Red/Blue, but it does matter for DMG-only games like Mickey that use more LCD functionality.)*

* **Minor fix:** Fix writes to $FF22 (NR43) to reset `counter_`. This was uncovered since the sound effect for taking damage in Mickey appeared to be skipped in all versions of Gambatte. Debugging showed the noise channel playing a single sample of the effect, then not producing sound until reaching `counter_` ~0.5 seconds later (after an $E7 write, implying ~2 Hz sound). Resetting `counter_` on $FF22 writes resulted in the proper behavior of playing the full sound effect.

All hwtests still pass after these changes, and no other regressions in behavior have been observed in testing (or in re-encodes of previous movies).