### PR TITLE
reset updates

### DIFF
--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -647,29 +647,29 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 	switch (platformId) {
 	case PLATFORM_GB:
 		info = { 0x100, 0x580A33B9, "DMG", "*.gb", "biosFilenameDMG" };
-		source_.setResetParams(0, 1, 1, 0);
+		source_.setResetParams(0, 0);
 		break;
 	case PLATFORM_GBC:
 		flags |= gambatte::GB::CGB_MODE;
 		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(0, 1, 1, 0);
+		source_.setResetParams(0, 0);
 		break;
 	case PLATFORM_GBA:
 		flags |= gambatte::GB::CGB_MODE;
 		flags |= gambatte::GB::GBA_FLAG;
 		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(0, 1, 1, 0);
+		source_.setResetParams(0, 0);
 		break;
 	case PLATFORM_GBP:
 		flags |= gambatte::GB::CGB_MODE;
 		flags |= gambatte::GB::GBA_FLAG;
 		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(4, 32, 37, 101 * (2 << 14));
+		source_.setResetParams(1234567, 101 * (2 << 14));
 		break;
 	case PLATFORM_SGB:
 		flags |= gambatte::GB::SGB_MODE;
 		info = { 0x100, 0xED48E98E, "SGB", "*.sgb", "biosFilenameSGB" };
-		source_.setResetParams(0, 1, 1, 128 * (2 << 14));
+		source_.setResetParams(0, 128 * (2 << 14));
 		break;
 	}
 

--- a/gambatte_qt/src/gambattesource.cpp
+++ b/gambatte_qt/src/gambattesource.cpp
@@ -158,11 +158,12 @@ GambatteSource::GambatteSource()
 , dpadLeftLast_(false)
 , tryReset_(false)
 , isResetting_(false)
-, resetFrameCount_(0)
-, resetBefore_(4)
-, resetFade_(32)
-, resetLimit_(37)
+, resetStage_(RESET_NOT)
+, resetCounter_(0)
+, resetFade_(1234567)
 , resetStall_(101 * (2 << 14))
+, rng_(std::random_device()())
+, dist35112_(0, 35111)
 {
 	gb_.setInputGetter((gambatte::InputGetter *)&GetInput::get, &inputGetter_);
 }
@@ -300,24 +301,25 @@ std::ptrdiff_t GambatteSource::update(
 	inputGetter_.is = packedInputState(inputState_, sizeof inputState_ / sizeof inputState_[0]);
 
 	samples -= overUpdate;
+
+	resetStepPre(samples);
+
 	std::ptrdiff_t const vidFrameSampleNo =
 		gb_.runFor(gbvidbuf.pixels, gbvidbuf.pitch,
 		           ptr_cast<quint32>(soundBuf), samples);
+
 	inputLog_.push(samples, inputGetter_.is);
+
+	resetStepPost(samples, pb);
+
 	if (vidFrameSampleNo >= 0)
 		inputDialog_->consumeAutoPress();
-
-	if (samplesToStall_ > 0)
-		samplesToStall_ = std::max((int)(samplesToStall_ - samples), 0);
 
 	return vidFrameSampleNo;
 }
 
 void GambatteSource::generateVideoFrame(PixelBuffer const &pb) {
 	if (void *const pbdata = getpbdata(pb, vsrci_)) {
-		if (tryReset_)
-			resetStep(pb, pbdata);
-
 		setPixelBuffer(pbdata, pb.pixelFormat, pb.pitch);
 		if (vfilter_) {
 			void          *dstbuf   = cconvert_ ? cconvert_->inBuf()   : pbdata;
@@ -356,7 +358,6 @@ void GambatteSource::tryReset() {
 	if(isResetting_)
 		return;
 	tryReset_ = true;
-	resetFrameCount_ = 0;
 }
 
 void GambatteSource::setResetting(bool state) {
@@ -364,43 +365,70 @@ void GambatteSource::setResetting(bool state) {
 	emit resetting(state);
 }
 
-void GambatteSource::resetStep(PixelBuffer const &pb, void *const pbdata) {
-	resetFrameCount_++;
-
-	if (resetFrameCount_ == 1)
-		setResetting(true);
-
-	unsigned pos = std::max((int)(std::min(resetFrameCount_, resetFade_) - resetBefore_), 0);
-	float multiplier = 1 - pos / (float)(resetFade_ - resetBefore_);
-	gambatte::uint_least32_t *intData =
-		static_cast<gambatte::uint_least32_t *>(cconvert_ ? cconvert_->inBuf() : pbdata);
-	std::ptrdiff_t pitch = cconvert_ ? cconvert_->inPitch() : pb.pitch;
-
-	for (unsigned y = 0; y < pb.height; y++) {
-		for (unsigned x = 0; x < pb.width; x++) {
-			int b = (int)(multiplier * ( intData[x]        & 0xFF));
-			int g = (int)(multiplier * ((intData[x] >>  8) & 0xFF));
-			int r = (int)(multiplier * ((intData[x] >> 16) & 0xFF));
-			intData[x] = b | (g << 8) | (r << 16);
+void GambatteSource::resetStepPre(std::size_t &samples) {
+	if (resetStage_ == RESET_NOT) {
+		if (tryReset_) {
+			tryReset_ = false;
+			setResetting(true);
+			resetStage_ = RESET_FADE;
+			resetCounter_ = resetFade_ + extraSamples();
 		}
-		intData += pitch;
-	}
-
-	if (resetFrameCount_ == resetLimit_) {
-		reset();
-		samplesToStall_ = resetStall_;
-	}
-
-	if (resetFrameCount_ >= resetLimit_ && samplesToStall_ == 0) {
-		tryReset_ = false;
-		setResetting(false);
+	} else {
+		samples = std::min(samples, (unsigned)resetCounter_);
 	}
 }
 
-void GambatteSource::setResetParams(unsigned before, unsigned fade,
-		unsigned limit, unsigned stall) {
-	resetBefore_ = before;
+void GambatteSource::resetStepPost(std::size_t &samples, PixelBuffer const &pb) {
+	if (resetStage_ == RESET_NOT)
+		return;
+
+	resetCounter_ -= samples;
+
+	if (resetCounter_ <= 0) {
+		if (resetStage_ == RESET_FADE) {
+			reset(resetStall_);
+			resetStage_ = RESET_STALL;
+			resetCounter_ = resetStall_;
+		} else if (resetStage_ == RESET_STALL) {
+			setResetting(false);
+			resetStage_ = RESET_NOT;
+			resetCounter_ = 0;
+		}
+	}
+
+	applyFade(pb);
+}
+
+void GambatteSource::applyFade(PixelBuffer const &pb) {
+	if (void *const pbdata = getpbdata(pb, vsrci_)) {
+		float alpha = 0.0f;
+
+		if (resetStage_ == RESET_FADE) {
+			float part = resetFade_ / 9.0f;
+			alpha = (resetCounter_ - part) / (resetFade_ - 2 * part);
+			alpha = std::min(std::max(alpha, 0.0f), 1.0f);
+		}
+
+		void          *dstbuf   = cconvert_ ? cconvert_->inBuf()   : pbdata;
+		std::ptrdiff_t dstpitch = cconvert_ ? cconvert_->inPitch() : pb.pitch;
+
+		uint_least32_t *intData = static_cast<uint_least32_t *>(dstbuf);
+
+		for (unsigned y = 0; y < pb.height; ++y) {
+			for (unsigned x = 0; x < pb.width; ++x) {
+				unsigned r = (intData[x] >> 16 & 0xFF) * alpha;
+				unsigned g = (intData[x] >>  8 & 0xFF) * alpha;
+				unsigned b = (intData[x]       & 0xFF) * alpha;
+
+				intData[x] = r << 16 | g << 8 | b;
+			}
+
+			intData += dstpitch;
+		}
+	}
+}
+
+void GambatteSource::setResetParams(unsigned fade, unsigned stall) {
 	resetFade_ = fade;
-	resetLimit_ = limit;
 	resetStall_ = stall;
 }

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -163,8 +163,8 @@ private:
 	GbVidBuf setPixelBuffer(void *pixels, PixelBuffer::PixelFormat format, std::ptrdiff_t pitch);
 	void setResetting(bool state);
 	void resetStepPre(std::size_t &samples);
-	void resetStepPost(std::size_t &samples, PixelBuffer const &pb);
-	void applyFade(PixelBuffer const &pb);
+	void resetStepPost(PixelBuffer const &pb, qint16 *const soundBuf, std::size_t &samples);
+	void applyFade(PixelBuffer const &pb, qint16 *const soundBuf, std::size_t &samples);
 
 	void emitSetTurbo(bool on) { if(!isResetting_) { emit setTurbo(on);} }
 	void emitPause() { if(!isResetting_) { emit togglePause();} }


### PR DESCRIPTION
subframe resets! randomly selecting where in a frame to reset was decided to be a reasonable solution partly based on GBP's own inconsistency. maybe don't advertise the random part so people don't attack "emulator RNG"

resets were cleaned up in general and audio is silenced when the fade starts to match GBP