### PR TITLE
save updates & psrdata.h

### DIFF
--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -35,8 +35,6 @@
 #include <fstream>
 #include <iostream>
 
-#define DEFAULT_GAMBATTE_PLATFORM PLATFORM_GBP
-
 namespace {
 
 static QString const strippedName(QString const &fullFileName) {
@@ -639,39 +637,13 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 	mw_.waitUntilPaused();
 
 	QSettings settings;
+
 	int platformId = settings.value("platform", DEFAULT_GAMBATTE_PLATFORM).toInt();
+	GambattePlatformInfo platform = gambatte_platform_info[platformId];
+	unsigned flags = platform.loadFlags;
+	GambatteBiosInfo info = platform.biosInfo;
 
-	unsigned flags = 0;
-	GambatteBiosInfo info;
-
-	switch (platformId) {
-	case PLATFORM_GB:
-		info = { 0x100, 0x580A33B9, "DMG", "*.gb", "biosFilenameDMG" };
-		source_.setResetParams(0, 0);
-		break;
-	case PLATFORM_GBC:
-		flags |= gambatte::GB::CGB_MODE;
-		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(0, 0);
-		break;
-	case PLATFORM_GBA:
-		flags |= gambatte::GB::CGB_MODE;
-		flags |= gambatte::GB::GBA_FLAG;
-		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(0, 0);
-		break;
-	case PLATFORM_GBP:
-		flags |= gambatte::GB::CGB_MODE;
-		flags |= gambatte::GB::GBA_FLAG;
-		info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename" };
-		source_.setResetParams(1234567, 101 * (2 << 14));
-		break;
-	case PLATFORM_SGB:
-		flags |= gambatte::GB::SGB_MODE;
-		info = { 0x100, 0xED48E98E, "SGB", "*.sgb", "biosFilenameSGB" };
-		source_.setResetParams(0, 128 * (2 << 14));
-		break;
-	}
+	source_.setResetParams(platform.resetFade, platform.resetStall);
 
 	if (miscDialog_->multicartCompat())
 		flags |= gambatte::GB::MULTICART_COMPAT;

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -707,6 +707,7 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 	bool goodRom = false;
 	for (PSRGoodromInfo good : psr_goodroms) {
 		if (romTitle.toStdString() == good.title && pak.crc() == good.crc) {
+			source_.setBreakpoint(good.savBreakpoint);
 			goodRom = true;
 			break;
 		}

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -705,25 +705,12 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 
 	// Basic good rom testing for PSR only. Fail doesn't mean it's a bad ROM for anything except English Gen1-2 games!!!
 	bool goodRom = false;
-	if(romTitle.toStdString() == "POKEMON RED" && pak.crc() == 0x9F7FDD53) {
-		goodRom = true;
+	for (PSRGoodromInfo good : psr_goodroms) {
+		if (romTitle.toStdString() == good.title && pak.crc() == good.crc) {
+			goodRom = true;
+			break;
+		}
 	}
-	if(romTitle.toStdString() == "POKEMON BLUE" && pak.crc() == 0xD6DA8A1A) {
-		goodRom = true;
-	}
-	if(romTitle.toStdString() == "POKEMON YELLOW" && pak.crc() == 0x7D527D62) {
-		goodRom = true;
-	}
-	if(romTitle.toStdString() == "POKEMON_GLDAAUE" && pak.crc() == 0x6BDE3C3E) {
-		goodRom = true;
-	}
-	if(romTitle.toStdString() == "POKEMON_SLVAAXE" && pak.crc() == 0x8AD48636) {
-		goodRom = true;
-	}
-	if(romTitle.toStdString() == "PM_CRYSTAL" && (pak.crc() == 0xEE6F5188 || pak.crc() == 0x3358E30A)) {
-		goodRom = true;
-	}
-	
 
 	QString revision = QString("interim");
 	#ifdef GAMBATTE_QT_VERSION_STR

--- a/gambatte_qt/src/gambattemenuhandler.h
+++ b/gambatte_qt/src/gambattemenuhandler.h
@@ -178,6 +178,7 @@ private:
 	int pauseInc_;
 	bool isResetting_;
 
+	void setWindowPrefix(QString const &windowPrefix);
 	void loadFile(QString const &fileName);
 	void setCurrentFile(QString const &fileName);
 	void setDmgPaletteColors();

--- a/gambatte_qt/src/gambattemenuhandler.h
+++ b/gambatte_qt/src/gambattemenuhandler.h
@@ -19,6 +19,7 @@
 #ifndef GAMBATTEMENUHANDLER_H
 #define GAMBATTEMENUHANDLER_H
 
+#include "psrdata.h"
 #include "scalingmethod.h"
 #include <QList>
 #include <QObject>
@@ -120,14 +121,6 @@ private slots:
 	void triggered();
 };
 
-enum GambattePlatform {
-	PLATFORM_GB  = 0,
-	PLATFORM_GBC = 1,
-	PLATFORM_GBA = 2,
-	PLATFORM_GBP = 3,
-	PLATFORM_SGB = 4
-};
-
 class GambattePlatformMenu : private QObject {
 public:
 	GambattePlatformMenu(MainWindow &mw);
@@ -149,15 +142,6 @@ private:
 
 private slots:
 	void triggered();
-};
-
-struct GambatteBiosInfo {
-	std::size_t size;
-	unsigned crc;
-
-	QString name;
-	QString filter;
-	QString key;
 };
 
 class GambatteMenuHandler : public QObject {

--- a/gambatte_qt/src/psrdata.h
+++ b/gambatte_qt/src/psrdata.h
@@ -92,18 +92,20 @@ const GambattePlatformInfo gambatte_platform_info[PLATFORM_COUNT] = {
 #define DEFAULT_GAMBATTE_PLATFORM PLATFORM_GBP
 
 struct PSRGoodromInfo {
-	std::string title; // cartridge header
+	std::string title; // from cartridge header
 	unsigned crc;      // CRC-32
+	int savBreakpoint;
 };
 
 const PSRGoodromInfo psr_goodroms[] = {
-	{ "POKEMON RED",      0x9F7FDD53 },
-	{ "POKEMON BLUE",     0xD6DA8A1A },
-	{ "POKEMON YELLOW",   0x7D527D62 },
-	{ "POKEMON_GLDAAUE",  0x6BDE3C3E },
-	{ "POKEMON_SLVAAXE",  0x8AD48636 },
-	{ "PM_CRYSTAL",       0xEE6F5188 }, // 1.0
-	{ "PM_CRYSTAL",       0x3358E30A }  // 1.1
+	{ "POKEMON RED",      0x9F7FDD53, 0x1C7847 },
+	{ "POKEMON BLUE",     0xD6DA8A1A, 0x1C7847 },
+	{ "POKEMON YELLOW",   0x7D527D62, 0x1C7B90 },
+	{ "POKEMON_GLDAAUE",  0x6BDE3C3E, 0x054D0D },
+	{ "POKEMON_SLVAAXE",  0x8AD48636, 0x054D0D },
+	{ "PM_CRYSTAL",       0xEE6F5188, 0x054C6A }, // 1.0
+	{ "PM_CRYSTAL",       0x3358E30A, 0x054C6A }, // 1.1
+	{ "POKECARD",         0x81069D53, 0x04524C }  // USA
 };
 
 #endif

--- a/gambatte_qt/src/psrdata.h
+++ b/gambatte_qt/src/psrdata.h
@@ -91,21 +91,24 @@ const GambattePlatformInfo gambatte_platform_info[PLATFORM_COUNT] = {
 
 #define DEFAULT_GAMBATTE_PLATFORM PLATFORM_GBP
 
-struct PSRGoodromInfo {
+struct GambatteGoodromInfo {
+	std::string label;
 	std::string title; // from cartridge header
 	unsigned crc;      // CRC-32
 	int savBreakpoint;
 };
 
-const PSRGoodromInfo psr_goodroms[] = {
-	{ "POKEMON RED",      0x9F7FDD53, 0x1C7847 },
-	{ "POKEMON BLUE",     0xD6DA8A1A, 0x1C7847 },
-	{ "POKEMON YELLOW",   0x7D527D62, 0x1C7B90 },
-	{ "POKEMON_GLDAAUE",  0x6BDE3C3E, 0x054D0D },
-	{ "POKEMON_SLVAAXE",  0x8AD48636, 0x054D0D },
-	{ "PM_CRYSTAL",       0xEE6F5188, 0x054C6A }, // 1.0
-	{ "PM_CRYSTAL",       0x3358E30A, 0x054C6A }, // 1.1
-	{ "POKECARD",         0x81069D53, 0x04524C }  // USA
+const std::string psr_label("<PSR>");
+
+const GambatteGoodromInfo gambatte_goodroms[] = {
+	{ psr_label, "POKEMON RED",      0x9F7FDD53, 0x1C7847 },
+	{ psr_label, "POKEMON BLUE",     0xD6DA8A1A, 0x1C7847 },
+	{ psr_label, "POKEMON YELLOW",   0x7D527D62, 0x1C7B90 },
+	{ psr_label, "POKEMON_GLDAAUE",  0x6BDE3C3E, 0x054D0D },
+	{ psr_label, "POKEMON_SLVAAXE",  0x8AD48636, 0x054D0D },
+	{ psr_label, "PM_CRYSTAL",       0xEE6F5188, 0x054C6A }, // 1.0
+	{ psr_label, "PM_CRYSTAL",       0x3358E30A, 0x054C6A }, // 1.1
+	{ psr_label, "POKECARD",         0x81069D53, 0x04524C }  // USA
 };
 
 #endif

--- a/gambatte_qt/src/psrdata.h
+++ b/gambatte_qt/src/psrdata.h
@@ -1,0 +1,94 @@
+//
+//   Copyright (C) 2011 by sinamas <sinamas at users.sourceforge.net>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License version 2 for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   version 2 along with this program; if not, write to the
+//   Free Software Foundation, Inc.,
+//   51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+
+#ifndef PSRDATA_H
+#define PSRDATA_H
+
+#include <gambatte.h>
+#include <QString>
+
+struct GambatteBiosInfo {
+	std::size_t size;
+	unsigned crc; // CRC-32 after byte @ 0xFE is set to 0x00
+
+	QString name;
+	QString filter;
+	QString key;
+};
+
+const GambatteBiosInfo dmg_bios_info = { 0x100, 0x580A33B9, "DMG", "*.gb",  "biosFilenameDMG" };
+const GambatteBiosInfo sgb_bios_info = { 0x100, 0xED48E98E, "SGB", "*.sgb", "biosFilenameSGB" };
+const GambatteBiosInfo cgb_bios_info = { 0x900, 0x31672598, "GBC", "*.gbc", "biosFilename"    };
+
+struct GambattePlatformInfo {
+	unsigned loadFlags;
+	GambatteBiosInfo biosInfo;
+	unsigned resetFade;  // uniform n=[0,35111] will be added
+	unsigned resetStall; // must be multiple of (2 << 14)
+};
+
+enum GambattePlatform {
+	PLATFORM_GB,
+	PLATFORM_GBC,
+	PLATFORM_GBA,
+	PLATFORM_GBP,
+	PLATFORM_SGB,
+
+	PLATFORM_COUNT
+};
+
+const GambattePlatformInfo gambatte_platform_info[PLATFORM_COUNT] = {
+	[PLATFORM_GB] = {
+		.loadFlags = 0,
+		.biosInfo = dmg_bios_info,
+		.resetFade = 0,
+		.resetStall = 0
+	},
+
+	[PLATFORM_GBC] = {
+		.loadFlags = gambatte::GB::CGB_MODE,
+		.biosInfo = cgb_bios_info,
+		.resetFade = 0,
+		.resetStall = 0
+	},
+
+	[PLATFORM_GBA] = {
+		.loadFlags = gambatte::GB::CGB_MODE | gambatte::GB::GBA_FLAG,
+		.biosInfo = cgb_bios_info, // patched with GBA_FLAG
+		.resetFade = 0,
+		.resetStall = 0
+	},
+
+	[PLATFORM_GBP] = {
+		.loadFlags = gambatte::GB::CGB_MODE | gambatte::GB::GBA_FLAG,
+		.biosInfo = cgb_bios_info, // patched with GBA_FLAG
+		.resetFade = 1234567,
+		.resetStall = 101 * (2 << 14)
+	},
+
+	[PLATFORM_SGB] = {
+		.loadFlags = gambatte::GB::SGB_MODE,
+		.biosInfo = sgb_bios_info,
+		.resetFade = 0,
+		.resetStall = 128 * (2 << 14)
+	}
+};
+
+#define DEFAULT_GAMBATTE_PLATFORM PLATFORM_GBP
+
+#endif

--- a/gambatte_qt/src/psrdata.h
+++ b/gambatte_qt/src/psrdata.h
@@ -91,4 +91,19 @@ const GambattePlatformInfo gambatte_platform_info[PLATFORM_COUNT] = {
 
 #define DEFAULT_GAMBATTE_PLATFORM PLATFORM_GBP
 
+struct PSRGoodromInfo {
+	std::string title; // cartridge header
+	unsigned crc;      // CRC-32
+};
+
+const PSRGoodromInfo psr_goodroms[] = {
+	{ "POKEMON RED",      0x9F7FDD53 },
+	{ "POKEMON BLUE",     0xD6DA8A1A },
+	{ "POKEMON YELLOW",   0x7D527D62 },
+	{ "POKEMON_GLDAAUE",  0x6BDE3C3E },
+	{ "POKEMON_SLVAAXE",  0x8AD48636 },
+	{ "PM_CRYSTAL",       0xEE6F5188 }, // 1.0
+	{ "PM_CRYSTAL",       0x3358E30A }  // 1.1
+};
+
 #endif

--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -72,7 +72,7 @@ if sys.platform == 'darwin':
 	sys_libs.append('System')
 
 shlib = env.SharedLibrary('gambatte', sourceFiles + ['src/cinterface.cpp'],
-                          CXXFLAGS = env['CXXFLAGS'] + ' -DDLLABLES' + rev(),
+                          CXXFLAGS = env['CXXFLAGS'] + rev(),
                           LINKFLAGS = env['LINKFLAGS'] + ' -s',
                           LIBS = sys_libs,
                           SHLIBPREFIX = "lib")

--- a/libgambatte/src/cpu.cpp
+++ b/libgambatte/src/cpu.cpp
@@ -529,7 +529,6 @@ void CPU::process(unsigned long const cycles) {
 		} else while (cycleCounter < mem_.nextEventTime()) {
 			unsigned char opcode;
 
-#ifdef DLLABLES
 			for (int i = 0; i < numInterruptAddresses; ++i) {
 				if (pc == (interruptAddresses[i] & 0xFFFF)) {
 					unsigned bank = interruptAddresses[i] >> 16;
@@ -544,7 +543,6 @@ void CPU::process(unsigned long const cycles) {
 
 			if (hitInterruptAddress != -1)
 				break;
-#endif
 
 			if (!prefetched_) {
 				PC_READ(opcode);

--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -53,10 +53,14 @@ public:
 		return 1;
 	}
 
+	virtual bool disabledRam() const {
+		return !enableRam_;
+	}
+
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
 		if (p < 0x2000) {
 			enableRam_ = (data & 0xF) == 0xA;
-			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 		}
 	}
 
@@ -66,7 +70,7 @@ public:
 
 	virtual void loadState(SaveState::Mem const &ss) {
 		enableRam_ = ss.enableRam;
-		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 	}
 
 private:
@@ -95,6 +99,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual bool disabledRam() const {
+		return !enableRam_;
 	}
 
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
@@ -150,7 +158,7 @@ private:
 	static unsigned adjustedRombank(unsigned bank) { return bank & 0x1F ? bank : bank | 1; }
 
 	void setRambank() const {
-		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0,
+		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled,
 		                    rambank_ & (rambanks(memptrs_) - 1));
 	}
 
@@ -171,11 +179,15 @@ public:
 		return rombank_;
 	}
 
+	virtual bool disabledRam() const {
+		return !enableRam_;
+	}
+
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
 		switch (p >> 13 & 3) {
 		case 0:
 			enableRam_ = (data & 0xF) == 0xA;
-			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 			break;
 		case 1:
 			rombank_ = (rombank_   & 0x60) | (data    & 0x1F);
@@ -204,7 +216,7 @@ public:
 		rombank_ = ss.rombank;
 		enableRam_ = ss.enableRam;
 		rombank0Mode_ = ss.rambankMode;
-		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 		setRombank();
 	}
 
@@ -245,11 +257,15 @@ public:
 		return rombank_;
 	}
 
+	virtual bool disabledRam() const {
+		return !enableRam_;
+	}
+
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
 		switch (p & 0x6100) {
 		case 0x0000:
 			enableRam_ = (data & 0xF) == 0xA;
-			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+			memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 			break;
 		case 0x2100:
 			rombank_ = data & 0xF;
@@ -266,7 +282,7 @@ public:
 	virtual void loadState(SaveState::Mem const &ss) {
 		rombank_ = ss.rombank;
 		enableRam_ = ss.enableRam;
-		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0, 0);
+		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled, 0);
 		memptrs_.setRombank(rombank_ & (rombanks(memptrs_) - 1));
 	}
 
@@ -289,6 +305,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual bool disabledRam() const {
+		return !enableRam_;
 	}
 
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const cc) {
@@ -335,7 +355,7 @@ private:
 	bool enableRam_;
 
 	void setRambank() const {
-		unsigned flags = enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0;
+		unsigned flags = enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled;
 
 		if (rtc_) {
 			rtc_->set(enableRam_, rambank_);
@@ -365,6 +385,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual bool disabledRam() const {
+		return false;
 	}
 
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
@@ -436,6 +460,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual bool disabledRam() const {
+		return false;
 	}
 
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
@@ -521,6 +549,10 @@ public:
 		return rombank_;
 	}
 
+	virtual bool disabledRam() const {
+		return !enableRam_;
+	}
+
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
 		switch (p >> 13 & 3) {
 		case 0:
@@ -563,7 +595,7 @@ private:
 	bool enableRam_;
 
 	void setRambank() const {
-		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0,
+		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled,
 		                    rambank_ & (rambanks(memptrs_) - 1));
 	}
 

--- a/libgambatte/src/mem/cartridge.h
+++ b/libgambatte/src/mem/cartridge.h
@@ -36,6 +36,7 @@ class Mbc {
 public:
 	virtual ~Mbc() {}
 	virtual unsigned char curRomBank() const = 0;
+	virtual bool disabledRam() const = 0;
 	virtual void romWrite(unsigned P, unsigned data, unsigned long cycleCounter) = 0;
 	virtual void saveState(SaveState::Mem &ss) const = 0;
 	virtual void loadState(SaveState::Mem const &ss) = 0;
@@ -64,6 +65,7 @@ public:
 	void setWrambank(unsigned bank) { memptrs_.setWrambank(bank); }
 	void setOamDmaSrc(OamDmaSrc oamDmaSrc) { memptrs_.setOamDmaSrc(oamDmaSrc); }
 	unsigned char curRomBank() const { return mbc_->curRomBank(); }
+	bool disabledRam() const { return mbc_->disabledRam(); }
 	void mbcWrite(unsigned addr, unsigned data, unsigned long const cc) { mbc_->romWrite(addr, data, cc); }
 	bool isCgb() const { return gambatte::isCgb(memptrs_); }
 	void resetCc(unsigned long const oldCc, unsigned long const newCc) { time_.resetCc(oldCc, newCc); }

--- a/libgambatte/src/mem/memptrs.h
+++ b/libgambatte/src/mem/memptrs.h
@@ -51,7 +51,8 @@ inline std::size_t wrambank_size() { return 0x1000; }
 
 class MemPtrs {
 public:
-	enum RamFlag { read_en = 1, write_en = 2, rtc_en = 4 };
+	enum RamFlag { read_en = 1, write_en = 2, rtc_en = 4,
+		disabled = read_en | rtc_en };
 
 	MemPtrs();
 	void reset(unsigned rombanks, unsigned rambanks, unsigned wrambanks);

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -55,6 +55,7 @@ Memory::Memory(Interrupter const &interrupter)
 , oamDmaPos_(-2u & 0xFF)
 , oamDmaStartPos_(0)
 , serialCnt_(0)
+, bus_(0xFF)
 , blanklcd_(false)
 , haltHdmaState_(hdma_low)
 {
@@ -692,6 +693,8 @@ unsigned Memory::nontrivial_read(unsigned const p, unsigned long const cc) {
 
 			if (cart_.rsrambankptr())
 				return cart_.rsrambankptr()[p];
+			else if (cart_.disabledRam())
+				return bus_;
             
 			if (cart_.isHuC3())
 				return cart_.HuC3Read(p, cc);

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -80,21 +80,24 @@ public:
 	void ackIrq(unsigned bit, unsigned long cc);
 
 	unsigned readBios(unsigned p) {
-		if(agbFlag_ && p >= 0xF3 && p < 0x100) {
-			return (agbOverride[p-0xF3] + bios_[p]) & 0xFF;
-		}
+		if(agbFlag_ && p >= 0xF3 && p < 0x100)
+			return (agbOverride[p - 0xF3] + bios_[p]) & 0xFF;
+
 		return bios_[p];
 	}
 
 	unsigned ff_read(unsigned p, unsigned long cc) {
-		return p < 0x80 ? nontrivial_ff_read(p, cc) : ioamhram_[p + 0x100];
+		bus_ = p < 0x80 ? nontrivial_ff_read(p, cc) : ioamhram_[p + 0x100];
+		return bus_;
 	}
 
 	unsigned read(unsigned p, unsigned long cc) {
 		if(biosMode_ && (p < biosSize_ && !(p >= 0x100 && p < 0x200))) {
-			return readBios(p);
-		}
-		return cart_.rmem(p >> 12) ? cart_.rmem(p >> 12)[p] : nontrivial_read(p, cc);
+			bus_ = readBios(p);
+		} else
+			bus_ = cart_.rmem(p >> 12) ? cart_.rmem(p >> 12)[p] : nontrivial_read(p, cc);
+
+		return bus_;
 	}
 
 	void write(unsigned p, unsigned data, unsigned long cc) {
@@ -189,6 +192,7 @@ private:
 	unsigned char oamDmaPos_;
 	unsigned char oamDmaStartPos_;
 	unsigned char serialCnt_;
+	unsigned char bus_;
 	bool blanklcd_;
 	bool biosMode_;
 	bool agbFlag_;


### PR DESCRIPTION
psrdata.h! all our stuff put into a file. could include other people's stuff too.

goodroms can include a breakpoint where the .sav will be written to disk, or -1 for no breakpoint. this is to prevent crashes from losing sram data players expected to have saved

GBP's consistent disabled-sram behaviour is now emulated. the behaviour is similar to other platforms, but their pulls from the system bus sometimes sets extra bits