### PR TITLE
Input handling fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gambatte_sdl/gambatte_sdl
 gambatte_qt/src/moc_*.cpp
 gambatte_qt/src/moc_*.h
 gambatte_qt/src/release/
+gambatte_qt/src/debug/
 gambatte_qt/bin/
 test/testrunner
 

--- a/gambatte_qt/src/framework/include/inputdialog.h
+++ b/gambatte_qt/src/framework/include/inputdialog.h
@@ -61,6 +61,8 @@ public:
 
 	explicit InputDialog(auto_vector<Button> &buttons, QWidget *parent = 0);
 	virtual ~InputDialog();
+	
+	void setJoystickThreshold(int threshold);
 
 	// These invoke Button::pressed/released for matching buttons
 	void keyPress(QKeyEvent const *);

--- a/gambatte_qt/src/framework/include/inputdialog.h
+++ b/gambatte_qt/src/framework/include/inputdialog.h
@@ -23,6 +23,7 @@
 #include "mutual.h"
 #include "SDL_event.h"
 #include <QDialog>
+#include <QMessageBox>
 #include <map>
 #include <vector>
 
@@ -71,8 +72,7 @@ public:
 	void consumeAutoPress();
 
 public slots:
-	virtual void accept();
-	virtual void reject();
+	virtual void done(int r);
 
 private:
 	struct MappedKey {
@@ -133,6 +133,8 @@ private:
 	void resetMapping();
 	void store();
 	void restore();
+	bool checkDuplicates();
+	void removeDuplicates();
 };
 
 #endif

--- a/gambatte_qt/src/framework/include/inputdialog.h
+++ b/gambatte_qt/src/framework/include/inputdialog.h
@@ -133,7 +133,7 @@ private:
 	void resetMapping();
 	void store();
 	void restore();
-	bool checkDuplicates();
+	bool validateInputBindings();
 	void removeProblemValues();
 };
 

--- a/gambatte_qt/src/framework/include/inputdialog.h
+++ b/gambatte_qt/src/framework/include/inputdialog.h
@@ -134,7 +134,7 @@ private:
 	void store();
 	void restore();
 	bool checkDuplicates();
-	void removeDuplicates();
+	void removeProblemValues();
 };
 
 #endif

--- a/gambatte_qt/src/framework/include/mainwindow.h
+++ b/gambatte_qt/src/framework/include/mainwindow.h
@@ -150,6 +150,8 @@ public:
 
 	/** speed = N, gives N times faster than normal when fastForward is enabled. */
 	void setFastForwardSpeed(int speed);
+	
+	void setJoystickThreshold(int threshold);
 
 	/** Sets the video mode that is used for full screen (see toggleFullScreen).
 	  * A screen is basically a monitor. A different full screen mode can be selected for each screen.

--- a/gambatte_qt/src/framework/src/inputbox.cpp
+++ b/gambatte_qt/src/framework/src/inputbox.cpp
@@ -348,6 +348,7 @@ InputBox::InputBox(QWidget *nextFocus)
 : nextFocus_(nextFocus)
 , timerId_(0)
 , ignoreCnt_(0)
+, threshold_(8192)
 {
 	setData(0, value_null);
 	connect(this, SIGNAL(textEdited(QString const &)), this, SLOT(textEditedSlot()));
@@ -414,7 +415,7 @@ void InputBox::timerEvent(QTimerEvent *) {
 
 	if (ignoreCnt_) {
 		ignoreCnt_--;
-	} else while (js_->pollEvent(&ev, 256)) {
+	} else while (js_->pollEvent(&ev, 256, threshold_)) {
 		switch (ev.type) {
 		case SDL_JOYAXISMOTION:
 		case SDL_JOYHATMOTION:

--- a/gambatte_qt/src/framework/src/inputbox.h
+++ b/gambatte_qt/src/framework/src/inputbox.h
@@ -30,6 +30,7 @@ public:
 	void setData(SDL_Event const &data) { setData(data.id, data.value); }
 	void setData(unsigned id, int value = value_kbd);
 	void setNextFocus(QWidget *nextFocus) { nextFocus_ = nextFocus; }
+	bool isEmpty() { return data_.value == value_null || (data_.value == value_kbd && data_.id == 0); }
 	SDL_Event const & data() const { return data_; }
 
 public slots:

--- a/gambatte_qt/src/framework/src/inputbox.h
+++ b/gambatte_qt/src/framework/src/inputbox.h
@@ -31,6 +31,7 @@ public:
 	void setData(unsigned id, int value = value_kbd);
 	void setNextFocus(QWidget *nextFocus) { nextFocus_ = nextFocus; }
 	bool isEmpty() { return data_.value == value_null || (data_.value == value_kbd && data_.id == 0); }
+	void setJoystickThreshold(int threshold) { threshold_ = threshold; }
 	SDL_Event const & data() const { return data_; }
 
 public slots:
@@ -54,6 +55,7 @@ private:
 	scoped_ptr<SdlJoystick::Locked> js_;
 	int timerId_;
 	int ignoreCnt_;
+	int threshold_;
 
 private slots:
 	void textEditedSlot() { setData(data_); }

--- a/gambatte_qt/src/framework/src/inputdialog.cpp
+++ b/gambatte_qt/src/framework/src/inputdialog.cpp
@@ -263,7 +263,7 @@ void InputDialog::store() {
 
 bool InputDialog::checkDuplicates() {
 	for(std::size_t i = 0; i < inputBoxes_.size(); ++i) {
-		for(std::size_t j = 0; j < i; ++j) {
+		for(std::size_t j = 0; j < i / 2 * 2; ++j) {
 			if(inputBoxes_[i] && inputBoxes_[j]
 					&& !inputBoxes_[i]->isEmpty()
 					&& !inputBoxes_[j]->isEmpty()
@@ -403,6 +403,8 @@ void InputDialog::done(int r) {
 		// ok pressed
 		if(!checkDuplicates()) {
 			store();
+			removeDuplicates();
+			restore();
 			QDialog::done(r);
 			return;
 		}

--- a/gambatte_qt/src/framework/src/inputdialog.cpp
+++ b/gambatte_qt/src/framework/src/inputdialog.cpp
@@ -261,7 +261,7 @@ void InputDialog::store() {
 	resetMapping();
 }
 
-bool InputDialog::checkDuplicates() {
+bool InputDialog::validateInputBindings() {
 	// also checks for shift
 	bool shiftBound = false;
 	for(std::size_t i = 0; i < inputBoxes_.size(); ++i) {
@@ -281,7 +281,7 @@ bool InputDialog::checkDuplicates() {
 					tr("Input Binding Error"),
 					buffer,
 					QMessageBox::Ok);
-				return true;
+				return false;
 			}
 		}
 	}
@@ -291,9 +291,9 @@ bool InputDialog::checkDuplicates() {
 			tr("Input Binding Warning"),
 			("Please note that using SHIFT as an input in combination with any key that it modifies may lead to buttons still being considered held after you release them. For best results, please choose another input button.\n\nTo continue on with SHIFT still bound press OK, if you want to change it press Cancel."),
 			QMessageBox::Ok | QMessageBox::Cancel);
-		return QMessageBox::Ok != button;
+		return QMessageBox::Ok == button;
 	}
-	return false;
+	return true;
 }
 
 void InputDialog::removeProblemValues() {
@@ -422,7 +422,7 @@ void InputDialog::consumeAutoPress() {
 void InputDialog::done(int r) {
 	if(QDialog::Accepted == r) {
 		// ok pressed
-		if(!checkDuplicates()) {
+		if(validateInputBindings()) {
 			store();
 			removeProblemValues();
 			restore();

--- a/gambatte_qt/src/framework/src/inputdialog.cpp
+++ b/gambatte_qt/src/framework/src/inputdialog.cpp
@@ -262,22 +262,36 @@ void InputDialog::store() {
 }
 
 bool InputDialog::checkDuplicates() {
+	// also checks for shift
+	bool shiftBound = false;
 	for(std::size_t i = 0; i < inputBoxes_.size(); ++i) {
+		if(inputBoxes_[i] && inputBoxes_[i]->data().value == InputBox::value_kbd && inputBoxes_[i]->data().id == Qt::Key_Shift) {
+			shiftBound = true;
+		}
 		for(std::size_t j = 0; j < i / 2 * 2; ++j) {
 			if(inputBoxes_[i] && inputBoxes_[j]
 					&& !inputBoxes_[i]->isEmpty()
 					&& !inputBoxes_[j]->isEmpty()
 					&& inputBoxes_[i]->data().value == inputBoxes_[j]->data().value
 					&& inputBoxes_[i]->data().id == inputBoxes_[j]->data().id) {
-				QMessageBox msgBox;
-				msgBox.setText("Error");
 				char buffer[512];
 				sprintf(buffer, "Keybind for %s and %s are equal. You may not bind the same keyboard/joystick input to more than one Gameboy input. Please adjust your inputs and try again.", buttons_[i/2]->label().toStdString().c_str(), buttons_[j/2]->label().toStdString().c_str());
-				msgBox.setInformativeText(buffer);
-				msgBox.exec();
+				QMessageBox::critical(
+					this,
+					tr("Input Binding Error"),
+					buffer,
+					QMessageBox::Ok);
 				return true;
 			}
 		}
+	}
+	if(shiftBound) {
+		QMessageBox::StandardButton button = QMessageBox::warning(
+			this,
+			tr("Input Binding Warning"),
+			("Please note that using SHIFT as an input in combination with any key that it modifies may lead to buttons still being considered held after you release them. For best results, please choose another input button.\n\nTo continue on with SHIFT still bound press OK, if you want to change it press Cancel."),
+			QMessageBox::Ok | QMessageBox::Cancel);
+		return QMessageBox::Ok != button;
 	}
 	return false;
 }

--- a/gambatte_qt/src/framework/src/inputdialog.cpp
+++ b/gambatte_qt/src/framework/src/inputdialog.cpp
@@ -156,8 +156,8 @@ InputDialog::InputDialog(auto_vector<Button> &buttons, QWidget *parent)
 			config_[i * 2    ].event.value =
 				settings.value(category + label + "Value1",
 				                 defaultKey
-				               ? InputBox::value_null
-				               : InputBox::value_kbd).toInt();
+				               ? InputBox::value_kbd
+				               : InputBox::value_null).toInt();
 			config_[i * 2    ].fpp = defaultFpp
 				? settings.value(category + label + "Fpp1", defaultFpp).toInt()
 				: 0;
@@ -167,22 +167,22 @@ InputDialog::InputDialog(auto_vector<Button> &buttons, QWidget *parent)
 			config_[i * 2 + 1].event.value =
 				settings.value(category + label + "Value2",
 				                 defaultAltKey
-				               ? InputBox::value_null
-				               : InputBox::value_kbd).toInt();
+				               ? InputBox::value_kbd
+				               : InputBox::value_null).toInt();
 			config_[i * 2 + 1].fpp = defaultFpp
 				? settings.value(category + label + "Fpp2", defaultFpp).toInt()
 				: 0;
 		} else {
 			config_[i * 2    ].event.id = defaultKey;
 			config_[i * 2    ].event.value = defaultKey
-			                               ? InputBox::value_null
-			                               : InputBox::value_kbd;
+			                               ? InputBox::value_kbd
+			                               : InputBox::value_null;
 			config_[i * 2    ].fpp = defaultFpp;
 
 			config_[i * 2 + 1].event.id = defaultAltKey;
 			config_[i * 2 + 1].event.value = defaultAltKey
-			                               ? InputBox::value_null
-			                               : InputBox::value_kbd;
+			                               ? InputBox::value_kbd
+			                               : InputBox::value_null;
 			config_[i * 2 + 1].fpp = defaultFpp;
 		}
 	}

--- a/gambatte_qt/src/framework/src/inputdialog.cpp
+++ b/gambatte_qt/src/framework/src/inputdialog.cpp
@@ -330,6 +330,14 @@ void InputDialog::restore() {
 	}
 }
 
+void InputDialog::setJoystickThreshold(int threshold) {
+	for (std::size_t i = 0; i < inputBoxes_.size(); ++i) {
+		if (inputBoxes_[i])
+			inputBoxes_[i]->setJoystickThreshold(threshold);
+	}
+
+}
+
 template<class AutoPressVec>
 static void setButtonPressed(AutoPressVec &v, InputDialog::Button *const button, int const fpp) {
 	if (fpp) {

--- a/gambatte_qt/src/framework/src/joysticklock.cpp
+++ b/gambatte_qt/src/framework/src/joysticklock.cpp
@@ -19,11 +19,10 @@
 #include "joysticklock.h"
 #include <map>
 
-static bool acceptEvent(SDL_Event &ev, int const insensitivity) {
+static bool acceptEvent(SDL_Event &ev, int const insensitivity, int const threshold) {
 	if (ev.type != SDL_JOYAXISMOTION)
 		return true;
-
-	enum { threshold = 8192 };
+	
 	typedef std::map<unsigned, int> Map;
 	static Map axisState;
 	Map::iterator const at =
@@ -60,12 +59,12 @@ static bool acceptEvent(SDL_Event &ev, int const insensitivity) {
 	return true;
 }
 
-int SdlJoystick::Locked::pollEvent(SDL_Event *ev, int insensitivity) {
+int SdlJoystick::Locked::pollEvent(SDL_Event *ev, int insensitivity, int threshold) {
 	int evValid;
 
 	do {
 		evValid = SDL_PollEvent(ev);
-	} while (evValid && !acceptEvent(*ev, insensitivity));
+	} while (evValid && !acceptEvent(*ev, insensitivity, threshold));
 
 	return evValid;
 }

--- a/gambatte_qt/src/framework/src/joysticklock.h
+++ b/gambatte_qt/src/framework/src/joysticklock.h
@@ -46,7 +46,7 @@ public:
 
 		// Wraps SDL_PollEvent, converting axis event values to
 		// axis_centered, axis_positive, or axis_negative.
-		int pollEvent(SDL_Event * , int insensitivity = 0);
+		int pollEvent(SDL_Event * , int insensitivity = 0, int threshold = 8192);
 
 		void update() { SDL_JoystickUpdate(); }
 		void clearEvents() { SDL_ClearEvents(); }

--- a/gambatte_qt/src/framework/src/mainwindow.cpp
+++ b/gambatte_qt/src/framework/src/mainwindow.cpp
@@ -132,6 +132,7 @@ ConstBlitterConf MainWindow::currentBlitterConf() const { return w_->currentBlit
 void MainWindow::frameStep() { w_->frameStep(); }
 void MainWindow::hideCursor() { w_->hideCursor(); }
 void MainWindow::setFastForwardSpeed(int speed) { w_->setFastForwardSpeed(speed); }
+void MainWindow::setJoystickThreshold(int threshold) { w_->setJoystickThreshold(threshold); }
 void MainWindow::setFastForward(bool enable) { w_->setFastForward(enable); }
 void MainWindow::pause(unsigned bitmask) { w_->pause(bitmask); }
 void MainWindow::unpause(unsigned bitmask) { w_->unpause(bitmask); }

--- a/gambatte_qt/src/framework/src/mediawidget.h
+++ b/gambatte_qt/src/framework/src/mediawidget.h
@@ -99,6 +99,7 @@ public:
 	}
 
 	void setFastForwardSpeed(int speed) { worker_->setFastForwardSpeed(speed); }
+	void setJoystickThreshold(int threshold) { worker_->setJoystickThreshold(threshold); }
 
 	void setMode(std::size_t screenNo, std::size_t resIndex, std::size_t rateIndex) {
 		fullModeToggler_->setMode(screenNo, resIndex, rateIndex);

--- a/gambatte_qt/src/framework/src/mediaworker.cpp
+++ b/gambatte_qt/src/framework/src/mediaworker.cpp
@@ -29,7 +29,6 @@
 #endif
 #include <cstdlib>
 #include <cstring>
-#include <QSettings>
 
 MediaWorker::MeanQueue::MeanQueue(long mean, long var)
 : q_(size, Elem(mean, var))
@@ -275,7 +274,6 @@ void MediaWorker::updateJoysticks() {
 		js.update();
 
 		SDL_Event ev;
-		QSettings settings;
 		while (js.pollEvent(&ev, 0, threshold_))
 			source().joystickEvent(ev);
 	}

--- a/gambatte_qt/src/framework/src/mediaworker.cpp
+++ b/gambatte_qt/src/framework/src/mediaworker.cpp
@@ -29,6 +29,7 @@
 #endif
 #include <cstdlib>
 #include <cstring>
+#include <QSettings>
 
 MediaWorker::MeanQueue::MeanQueue(long mean, long var)
 : q_(size, Elem(mean, var))
@@ -150,6 +151,7 @@ MediaWorker::MediaWorker(MediaSource &source,
 , sourceUpdater_(source)
 , ao_(new AudioOut(ae, aerate, aelatency, aevolume, resamplerNo))
 , usecft_(0)
+, threshold_(8192)
 {
 }
 
@@ -273,7 +275,8 @@ void MediaWorker::updateJoysticks() {
 		js.update();
 
 		SDL_Event ev;
-		while (js.pollEvent(&ev))
+		QSettings settings;
+		while (js.pollEvent(&ev, 0, threshold_))
 			source().joystickEvent(ev);
 	}
 }

--- a/gambatte_qt/src/framework/src/mediaworker.h
+++ b/gambatte_qt/src/framework/src/mediaworker.h
@@ -68,6 +68,8 @@ public:
 
 	void setFastForwardSpeed(int speed) { turboSkip_.setSpeed(speed); }
 	int fastForwardSpeed() const { return turboSkip_.speed(); }
+	void setJoystickThreshold(int threshold) { threshold_ = threshold; }
+	int threshold() const { return threshold_; }
 	void setFastForward(bool enable);
 	bool fastForward() const { return turboSkip_.isEnabled(); }
 
@@ -185,6 +187,7 @@ private:
 	Array<qint16> sndOutBuffer_;
 	scoped_ptr<AudioOut> ao_;
 	long usecft_;
+	int threshold_;
 
 	friend class PushMediaWorkerCall;
 	long adaptToRateEstimation(long estft);

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -901,6 +901,8 @@ void GambatteMenuHandler::miscDialogChange() {
 	mw_.callInWorkerThread(setSaveDirFun);
 	mw_.setDwmTripleBuffer(miscDialog_->dwmTripleBuf());
 	mw_.setFastForwardSpeed(miscDialog_->turboSpeed());
+	mw_.setJoystickThreshold(miscDialog_->threshold());
+	source_.inputDialog()->setJoystickThreshold(miscDialog_->threshold());
 	mw_.setPauseOnFocusOut(miscDialog_->pauseOnFocusOut() ? 2 : 0);
 	pauseInc_ = miscDialog_->pauseOnDialogs() ? 4 : 0;
 }

--- a/gambatte_qt/src/gambattesource.cpp
+++ b/gambatte_qt/src/gambattesource.cpp
@@ -259,8 +259,8 @@ GambatteSource::GbVidBuf GambatteSource::setPixelBuffer(
 static void setGbDir(bool &a, bool &b,
 		bool const aPressed, bool const bPressed, bool const preferA) {
 	if (aPressed & bPressed) {
-		a =  aPressed & preferA;
-		b = (aPressed & preferA) ^ 1;
+		a = false;
+		b = false;
 	} else {
 		a = aPressed;
 		b = bPressed;

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -89,7 +89,7 @@ public:
 	#endif
 	}
 
-	QDialog * inputDialog() const { return inputDialog_; }
+	InputDialog * inputDialog() const { return inputDialog_; }
 	void saveState(PixelBuffer const &fb);
 
 	void loadState() {

--- a/gambatte_qt/src/miscdialog.cpp
+++ b/gambatte_qt/src/miscdialog.cpp
@@ -42,13 +42,15 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
                     std::make_pair(tr("Same folder as ROM image"), QString()),
                     this)
 , turboSpeed_(8)
-, threshold_(8192)
+, threshold_(25)
 {
 	setWindowTitle(tr("Miscellaneous Settings"));
 	turboSpeedBox->setRange(2, 16);
 	turboSpeedBox->setSuffix("x");
 	
-	thresholdBox->setRange(8192, 24576);
+	thresholdBox->setRange(25, 75);
+	thresholdBox->setSuffix("%");
+	
 
 	QVBoxLayout *const mainLayout = new QVBoxLayout(this);
 	QVBoxLayout *const topLayout = addLayout(mainLayout, new QVBoxLayout);
@@ -103,8 +105,8 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
 
 	turboSpeed_ = std::min(std::max(QSettings().value("misc/turboSpeed", turboSpeed_).toInt(), 2),
 	                       16);
-    threshold_ = std::min(std::max(QSettings().value("misc/joystickThreshold", threshold_).toInt(), 8192),
-	                      24576);
+    threshold_ = std::min(std::max(QSettings().value("misc/joystickThreshold", threshold_).toInt(), 25),
+	                      75);
 	restore();
 }
 

--- a/gambatte_qt/src/miscdialog.cpp
+++ b/gambatte_qt/src/miscdialog.cpp
@@ -30,6 +30,7 @@
 MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
 : QDialog(parent)
 , turboSpeedBox(new QSpinBox(this))
+, thresholdBox(new QSpinBox(this))
 , pauseOnDialogs_(new QCheckBox(tr("Pause when displaying dialogs"), this), "misc/pauseOnDialogs", true)
 , pauseOnFocusOut_(new QCheckBox(tr("Pause on focus out"), this), "misc/pauseOnFocusOut", false)
 , fpsSelector_(this)
@@ -41,10 +42,13 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
                     std::make_pair(tr("Same folder as ROM image"), QString()),
                     this)
 , turboSpeed_(8)
+, threshold_(8192)
 {
 	setWindowTitle(tr("Miscellaneous Settings"));
 	turboSpeedBox->setRange(2, 16);
 	turboSpeedBox->setSuffix("x");
+	
+	thresholdBox->setRange(8192, 24576);
 
 	QVBoxLayout *const mainLayout = new QVBoxLayout(this);
 	QVBoxLayout *const topLayout = addLayout(mainLayout, new QVBoxLayout);
@@ -53,6 +57,12 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
 		QHBoxLayout *hLayout = addLayout(topLayout, new QHBoxLayout);
 		hLayout->addWidget(new QLabel(tr("Fast-forward speed:")));
 		hLayout->addWidget(turboSpeedBox);
+	}
+	
+	{
+		QHBoxLayout *hLayout = addLayout(topLayout, new QHBoxLayout);
+		hLayout->addWidget(new QLabel(tr("Joystick deadzone threshold:")));
+		hLayout->addWidget(thresholdBox);
 	}
 
 	addLayout(topLayout, new QHBoxLayout)->addWidget(pauseOnDialogs_.checkBox());
@@ -93,17 +103,21 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
 
 	turboSpeed_ = std::min(std::max(QSettings().value("misc/turboSpeed", turboSpeed_).toInt(), 2),
 	                       16);
+    threshold_ = std::min(std::max(QSettings().value("misc/joystickThreshold", threshold_).toInt(), 8192),
+	                      24576);
 	restore();
 }
 
 MiscDialog::~MiscDialog() {
 	QSettings settings;
 	settings.setValue("misc/turboSpeed", turboSpeed_);
+	settings.setValue("misc/joystickThreshold", threshold_);
 }
 
 void MiscDialog::restore() {
 	fpsSelector_.reject();
 	turboSpeedBox->setValue(turboSpeed_);
+	thresholdBox->setValue(threshold_);
 	pauseOnDialogs_.reject();
 	pauseOnFocusOut_.reject();
 	dwmTripleBuf_.reject();
@@ -114,6 +128,7 @@ void MiscDialog::restore() {
 void MiscDialog::accept() {
 	fpsSelector_.accept();
 	turboSpeed_ = turboSpeedBox->value();
+	threshold_ = thresholdBox->value();
 	pauseOnDialogs_.accept();
 	pauseOnFocusOut_.accept();
 	dwmTripleBuf_.accept();

--- a/gambatte_qt/src/miscdialog.h
+++ b/gambatte_qt/src/miscdialog.h
@@ -31,6 +31,7 @@ public:
 	explicit MiscDialog(QString const &savePath, QWidget *parent = 0);
 	virtual ~MiscDialog();
 	int turboSpeed() const { return turboSpeed_; }
+	int threshold() const { return threshold_; }
 	bool pauseOnDialogs() const { return pauseOnDialogs_.value() | pauseOnFocusOut_.value(); }
 	bool pauseOnFocusOut() const { return pauseOnFocusOut_.value(); }
 	bool dwmTripleBuf() const { return dwmTripleBuf_.value(); }
@@ -44,6 +45,7 @@ public slots:
 
 private:
 	QSpinBox *const turboSpeedBox;
+	QSpinBox *const thresholdBox;
 	PersistCheckBox pauseOnDialogs_;
 	PersistCheckBox pauseOnFocusOut_;
 	FpsSelector fpsSelector_;
@@ -51,6 +53,7 @@ private:
 	PersistCheckBox multicartCompat_;
 	PathSelector savepathSelector_;
 	int turboSpeed_;
+	int threshold_;
 
 	void restore();
 };

--- a/gambatte_qt/src/miscdialog.h
+++ b/gambatte_qt/src/miscdialog.h
@@ -31,7 +31,7 @@ public:
 	explicit MiscDialog(QString const &savePath, QWidget *parent = 0);
 	virtual ~MiscDialog();
 	int turboSpeed() const { return turboSpeed_; }
-	int threshold() const { return threshold_; }
+	int threshold() const { return threshold_ * 32768 / 100; }
 	bool pauseOnDialogs() const { return pauseOnDialogs_.value() | pauseOnFocusOut_.value(); }
 	bool pauseOnFocusOut() const { return pauseOnFocusOut_.value(); }
 	bool dwmTripleBuf() const { return dwmTripleBuf_.value(); }


### PR DESCRIPTION
- Up+down and Left+right cancel each other out (closes #23 )
- No longer allowed to bind the same keyboard/controller input to more than one GB input at once
- Fix bug where all unbound inputs are registered as pressed when ´ is pressed on German keyboards (probably happens on other keys as well)
- Warn user when they try to save inputs if SHIFT is selected (as it can lead to inputs being falsely registered as still held when SHIFT + a key that it modifies are used at the same time)
- Allow configuring joystick deadzone threshold (between 25% and 75%)