### PR TITLE
Pre-release cleanups (Feb 2020)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ gambatte_qt/.qmake.stash
 gambatte_qt/src/platforms.pri
 
 .vs/
+.vscode/
 
 *.os
 *.so

--- a/gambatte_qt/src/fpsselector.cpp
+++ b/gambatte_qt/src/fpsselector.cpp
@@ -46,10 +46,10 @@ FpsSelector::FpsSelector(QWidget *widgetParent)
 {
 	comboBox_->addItem("GB/GBC (" + QString::number(262144.0 / 4389.0) + " fps)",
 	                   QSize(262144, 4389));
-#if !defined(ENABLE_TURBO_BUTTONS)
+#ifndef ENABLE_FRAMERATE_BUTTONS
     comboBox_->setHidden(true);
 #endif
-#ifdef ENABLE_TURBO_BUTTONS
+#ifdef ENABLE_FRAMERATE_BUTTONS
 	comboBox_->addItem(tr("Other..."));
 
 	QSize const &loadedValue = QSettings().value("misc/fps", value_).toSize();
@@ -81,7 +81,7 @@ QWidget * FpsSelector::widget() const {
 }
 
 void FpsSelector::indexChanged(int const index) {
-#ifdef ENABLE_TURBO_BUTTONS
+#ifdef ENABLE_FRAMERATE_BUTTONS
 	if (getCustomIndex(comboBox_) == index) {
 		bool ok = false;
 		double const fps =

--- a/gambatte_qt/src/framework/src/addaudioengines_win32.cpp
+++ b/gambatte_qt/src/framework/src/addaudioengines_win32.cpp
@@ -25,5 +25,5 @@ void addAudioEngines(auto_vector<AudioEngine> &audioEngines, WId winId) {
 	if (WasapiEngine::isUsable())
 		audioEngines.push_back(new WasapiEngine);
 
-	audioEngines.push_back(new DirectSoundEngine(winId));
+	audioEngines.push_back(new DirectSoundEngine((HWND)winId));
 }

--- a/gambatte_qt/src/framework/src/blitterwidgets/direct3dblitter.cpp
+++ b/gambatte_qt/src/framework/src/blitterwidgets/direct3dblitter.cpp
@@ -178,7 +178,7 @@ void Direct3DBlitter::getPresentParams(D3DPRESENT_PARAMETERS *const presentParam
 	bool excl = exclusive && flipping_.value();
 	if (gdiSettings.monitorFromWindow
 			&& d3d->GetAdapterMonitor(adapterIndex)
-			   != gdiSettings.monitorFromWindow(parentWidget()->parentWidget()->winId(),
+			   != gdiSettings.monitorFromWindow((HWND)parentWidget()->parentWidget()->winId(),
 			                                    GdiSettings::MON_DEFAULTTONEAREST)) {
 		excl = false;
 	}
@@ -197,7 +197,7 @@ void Direct3DBlitter::getPresentParams(D3DPRESENT_PARAMETERS *const presentParam
 	presentParams->MultiSampleType = D3DMULTISAMPLE_NONE;
 	presentParams->MultiSampleQuality = 0;
 	presentParams->SwapEffect = excl ? D3DSWAPEFFECT_FLIP : D3DSWAPEFFECT_DISCARD;
-	presentParams->hDeviceWindow = excl ? parentWidget()->parentWidget()->winId() : winId();
+	presentParams->hDeviceWindow = (HWND)(excl ? parentWidget()->parentWidget()->winId() : winId());
 	presentParams->Windowed = excl ? FALSE : TRUE;
 	presentParams->EnableAutoDepthStencil = FALSE;
 	presentParams->AutoDepthStencilFormat = D3DFMT_UNKNOWN;
@@ -357,7 +357,7 @@ void Direct3DBlitter::exclusiveChange() {
 		} else if (!windowed) {
 			ModeLock mlock(d3d->GetAdapterMonitor(adapterIndex));
 			resetDevice();
-			SetWindowPos(parentWidget()->parentWidget()->winId(),
+			SetWindowPos((HWND)parentWidget()->parentWidget()->winId(),
 			             HWND_NOTOPMOST, 0, 0, 0, 0,
 			             SWP_NOMOVE | SWP_NOSIZE);
 		}
@@ -442,7 +442,7 @@ void Direct3DBlitter::init() {
 		for (int n = 2; n--;) {
 			if (!FAILED(d3d->CreateDevice(
 					adapterIndex, D3DDEVTYPE_HAL,
-					parentWidget()->parentWidget()->winId(),
+					(HWND)parentWidget()->parentWidget()->winId(),
 					D3DCREATE_FPU_PRESERVE | D3DCREATE_SOFTWARE_VERTEXPROCESSING,
 					&presentParams, &device))) {
 				break;

--- a/gambatte_qt/src/framework/src/blitterwidgets/directdrawblitter.cpp
+++ b/gambatte_qt/src/framework/src/blitterwidgets/directdrawblitter.cpp
@@ -283,7 +283,7 @@ void DirectDrawBlitter::init() {
 	DWORD const sclFlags = exclusive && flipping_.value()
 	                     ? DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN
 	                     : DDSCL_NORMAL;
-	if (lpDD->SetCooperativeLevel(parentWidget()->parentWidget()->winId(), sclFlags) != DD_OK) {
+	if (lpDD->SetCooperativeLevel((HWND)parentWidget()->parentWidget()->winId(), sclFlags) != DD_OK) {
 		std::cerr << "SetCooperativeLevel failed" << std::endl;
 		return uninit();
 	}
@@ -291,7 +291,7 @@ void DirectDrawBlitter::init() {
 		std::cerr << "CreateClipper failed" << std::endl;
 		return uninit();
 	}
-	if (lpClipper->SetHWnd(0, winId()) != DD_OK) {
+	if (lpClipper->SetHWnd(0, (HWND)winId()) != DD_OK) {
 		std::cerr << "SetHWnd failed" << std::endl;
 		return uninit();
 	}
@@ -476,20 +476,20 @@ HRESULT DirectDrawBlitter::backBlit(
 
 void DirectDrawBlitter::finalBlit(DWORD const waitflag) {
 	if (clear && exclusive && flipping_.value() && !blitted) {
-		lpClipper->SetHWnd(0, parentWidget()->parentWidget()->winId());
+		lpClipper->SetHWnd(0, (HWND)parentWidget()->parentWidget()->winId());
 
 		RECT rcRectDest;
-		GetWindowRect(parentWidget()->parentWidget()->winId(), &rcRectDest);
+		GetWindowRect((HWND)parentWidget()->parentWidget()->winId(), &rcRectDest);
 
 		bool const success = backBlit(lpDDSClear, &rcRectDest, waitflag) == DD_OK;
-		lpClipper->SetHWnd(0, winId());
+		lpClipper->SetHWnd(0, (HWND)winId());
 		clear -= success;
 		if (!success)
 			return;
 	}
 
 	RECT rcRectDest;
-	GetWindowRect(winId(), &rcRectDest);
+	GetWindowRect((HWND)winId(), &rcRectDest);
 	blitted |= backBlit(lpDDSVideo, &rcRectDest, waitflag) == DD_OK;
 }
 

--- a/gambatte_qt/src/framework/src/dwmcontrol.cpp
+++ b/gambatte_qt/src/framework/src/dwmcontrol.cpp
@@ -120,7 +120,7 @@ static void setDwmTripleBuffer(HWND const hwnd, bool const enable) {
 }
 
 HWND getWidgetHWND(QWidget* widget) {
-	if(const QWindow *w = widget->windowHandle()) {
+	if(QWindow *w = widget->windowHandle()) {
 			return (HWND)QGuiApplication::platformNativeInterface()->nativeResourceForWindow(QByteArrayLiteral("handle"), w);
 	}
 	return NULL;

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -84,15 +84,15 @@ FrameRateAdjuster::FrameRateAdjuster(MiscDialog const &miscDialog, MainWindow &m
 , resetFrameRateAction_(new QAction(tr("&Reset Frame Rate"), &mw))
 , enabled_(true)
 {
-#ifdef ENABLE_TURBO_BUTTONS
+#ifdef ENABLE_FRAMERATE_BUTTONS
 	decFrameRateAction_->setShortcut(QString("Ctrl+D"));
 	incFrameRateAction_->setShortcut(QString("Ctrl+I"));
 	resetFrameRateAction_->setShortcut(QString("Ctrl+U"));
-#endif
 
 	connect(decFrameRateAction_,   SIGNAL(triggered()), this, SLOT(decFrameRate()));
 	connect(incFrameRateAction_,   SIGNAL(triggered()), this, SLOT(incFrameRate()));
 	connect(resetFrameRateAction_, SIGNAL(triggered()), this, SLOT(resetFrameRate()));
+#endif
 	connect(&miscDialog, SIGNAL(accepted()), this, SLOT(miscDialogChange()));
 	changed();
 }
@@ -117,25 +117,21 @@ void FrameRateAdjuster::setDisabled(bool disabled) {
 }
 
 void FrameRateAdjuster::decFrameRate() {
-#ifdef ENABLE_TURBO_BUTTONS
 	if (static_cast<GambatteMenuHandler *>(this->parent())->isResetting())
 		return;
 	if (enabled_) {
 		frameTime_.inc();
 		changed();
 	}
-#endif
 }
 
 void FrameRateAdjuster::incFrameRate() {
-#ifdef ENABLE_TURBO_BUTTONS
 	if (static_cast<GambatteMenuHandler *>(this->parent())->isResetting())
 		return;
 	if (enabled_) {
 		frameTime_.dec();
 		changed();
 	}
-#endif
 }
 
 void FrameRateAdjuster::resetFrameRate() {
@@ -454,6 +450,8 @@ GambatteMenuHandler::GambatteMenuHandler(MainWindow &mw,
 		pauseAction_->setCheckable(true);
 		romLoadedActions->addAction(playm->addAction(tr("Frame &Step"),
 		                            this, SLOT(frameStep()), QString("Ctrl+.")));
+
+	#ifdef ENABLE_FRAMERATE_BUTTONS
 		playm->addSeparator();
 		syncFrameRateAction_ = playm->addAction(tr("&Sync Frame Rate to Refresh Rate"));
 		syncFrameRateAction_->setCheckable(true);
@@ -464,12 +462,13 @@ GambatteMenuHandler::GambatteMenuHandler(MainWindow &mw,
 
 		foreach (QAction *action, frameRateAdjuster->actions())
 			playm->addAction(romLoadedActions->addAction(action));
+	#endif
 
-		#ifdef ENABLE_INPUT_LOG
+	#ifdef ENABLE_INPUT_LOG
 		playm->addSeparator();
 		romLoadedActions->addAction(playm->addAction(
 			tr("&Save Input Log As..."), this, SLOT(saveInputLogAs())));
-		#endif
+	#endif
 
 		cmdactions += playm->actions();
 	}
@@ -664,12 +663,12 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 		mw_.stop();
 		emit dmgRomLoaded(false);
 		emit romLoaded(false);
-		QMessageBox::StandardButton button = QMessageBox::critical(
+		QMessageBox::StandardButton button = QMessageBox::warning(
 			&mw_,
 			tr("Bios Load Error"),
 			(tr("Could not load ") + info.name + tr(" bios.\n") +
 			"Gambatte-Speedrun requires a " + info.name + " bios for the selected platform.\n" +
-			"Please specify the location of such a file."),
+			"Please click OK to specify the location of such a file."),
 			QMessageBox::Ok | QMessageBox::Cancel);
 		if (button == QMessageBox::Ok)
 			openBios(info);
@@ -920,6 +919,7 @@ void GambatteMenuHandler::cheatDialogChange() {
 }
 
 void GambatteMenuHandler::reconsiderSyncFrameRateActionEnable() {
+#ifdef ENABLE_FRAMERATE_BUTTONS
 	if (mw_.blitterConf(videoDialog_->blitterNo()).maxSwapInterval()
 			&& !MainWindow::isDwmCompositionEnabled()) {
 		syncFrameRateAction_->setEnabled(true);
@@ -929,6 +929,7 @@ void GambatteMenuHandler::reconsiderSyncFrameRateActionEnable() {
 
 		syncFrameRateAction_->setEnabled(false);
 	}
+#endif
 }
 
 void GambatteMenuHandler::execGlobalPaletteDialog() {

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -465,9 +465,11 @@ GambatteMenuHandler::GambatteMenuHandler(MainWindow &mw,
 		foreach (QAction *action, frameRateAdjuster->actions())
 			playm->addAction(romLoadedActions->addAction(action));
 
+		#ifdef ENABLE_INPUT_LOG
 		playm->addSeparator();
 		romLoadedActions->addAction(playm->addAction(
 			tr("&Save Input Log As..."), this, SLOT(saveInputLogAs())));
+		#endif
 
 		cmdactions += playm->actions();
 	}

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -666,11 +666,13 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 		QMessageBox::StandardButton button = QMessageBox::warning(
 			&mw_,
 			tr("Bios Load Error"),
-			(tr("Could not load ") + info.name + tr(" bios.\n") +
-			"Gambatte-Speedrun requires a " + info.name + " bios for the selected platform.\n" +
-			"Please click OK to specify the location of such a file."),
-			QMessageBox::Ok | QMessageBox::Cancel);
-		if (button == QMessageBox::Ok)
+			("Gambatte-Speedrun requires a " + info.name + " bios for the selected platform.\n\n" +
+			"The bios (or boot ROM) is a .bin file you'll need to acquire before continuing.\n\n" +
+			"Gambatte-Speedrun does not distribute this file, but you may be able to acquire it " +
+			"through similar methods used for other ROMs.\n\n" +
+			"Please press Open to specify the location of this file."),
+			QMessageBox::Open | QMessageBox::Cancel);
+		if (button == QMessageBox::Open)
 			openBios(info);
 		return;
 	}

--- a/gambatte_qt/src/gambattesource.cpp
+++ b/gambatte_qt/src/gambattesource.cpp
@@ -309,7 +309,9 @@ std::ptrdiff_t GambatteSource::update(
 		runFor(gbvidbuf.pixels, gbvidbuf.pitch,
 		       ptr_cast<quint32>(soundBuf), samples);
 
+	#ifdef ENABLE_INPUT_LOG
 	inputLog_.push(samples, inputGetter_.is);
+	#endif
 
 	resetStepPost(pb, soundBuf, samples);
 

--- a/gambatte_qt/src/gambattesource.cpp
+++ b/gambatte_qt/src/gambattesource.cpp
@@ -405,7 +405,7 @@ void GambatteSource::resetStepPre(std::size_t &samples) {
 			resetCounter_ = resetFade_ + extraSamples();
 		}
 	} else {
-		samples = std::min(samples, (unsigned)resetCounter_);
+		samples = std::min(samples, (std::size_t)resetCounter_);
 	}
 }
 

--- a/gambatte_qt/src/gambattesource.cpp
+++ b/gambatte_qt/src/gambattesource.cpp
@@ -309,9 +309,9 @@ std::ptrdiff_t GambatteSource::update(
 		runFor(gbvidbuf.pixels, gbvidbuf.pitch,
 		       ptr_cast<quint32>(soundBuf), samples);
 
-	#ifdef ENABLE_INPUT_LOG
+#ifdef ENABLE_INPUT_LOG
 	inputLog_.push(samples, inputGetter_.is);
-	#endif
+#endif
 
 	resetStepPost(pb, soundBuf, samples);
 

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -40,9 +40,9 @@ public:
 
 	gambatte::LoadRes load(std::string const &romfile, unsigned flags) {
 		gambatte::LoadRes res = gb_.load(romfile, flags);
-		#ifdef ENABLE_INPUT_LOG
+	#ifdef ENABLE_INPUT_LOG
 		inputLog_.restart(gb_);
-		#endif
+	#endif
 
 		setBreakpoint(-1);
 		enableBreakpoint(false);
@@ -59,13 +59,13 @@ public:
 
 	void reset(unsigned samplesToStall) {
 		std::string revision = "interim";
-		#ifdef GAMBATTE_QT_VERSION_STR
+	#ifdef GAMBATTE_QT_VERSION_STR
 		revision = GAMBATTE_QT_VERSION_STR;
-		#endif
+	#endif
 		gb_.reset(samplesToStall, revision);
-		#ifdef ENABLE_INPUT_LOG
+	#ifdef ENABLE_INPUT_LOG
 		inputLog_.push(0, 0xFF);
-		#endif
+	#endif
 	}
 
 	void setDmgPaletteColor(int palNum, int colorNum, unsigned long rgb32) {
@@ -84,9 +84,9 @@ public:
 
 	void loadState(std::string const &filepath) {
 		gb_.loadState(filepath);
-		#ifdef ENABLE_INPUT_LOG
+	#ifdef ENABLE_INPUT_LOG
 		inputLog_.restart(gb_);
-		#endif
+	#endif
 	}
 
 	QDialog * inputDialog() const { return inputDialog_; }
@@ -94,9 +94,9 @@ public:
 
 	void loadState() {
 		gb_.loadState();
-		#ifdef ENABLE_INPUT_LOG
+	#ifdef ENABLE_INPUT_LOG
 		inputLog_.restart(gb_);
-		#endif
+	#endif
 	}
 
 	void tryReset();

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -40,7 +40,9 @@ public:
 
 	gambatte::LoadRes load(std::string const &romfile, unsigned flags) {
 		gambatte::LoadRes res = gb_.load(romfile, flags);
+		#ifdef ENABLE_INPUT_LOG
 		inputLog_.restart(gb_);
+		#endif
 
 		setBreakpoint(-1);
 		enableBreakpoint(false);
@@ -56,8 +58,14 @@ public:
 	void setGameShark(std::string const &codes) { gb_.setGameShark(codes); }
 
 	void reset(unsigned samplesToStall) {
-		gb_.reset(samplesToStall, GAMBATTE_QT_VERSION_STR);
+		std::string revision = "interim";
+		#ifdef GAMBATTE_QT_VERSION_STR
+		revision = GAMBATTE_QT_VERSION_STR;
+		#endif
+		gb_.reset(samplesToStall, revision);
+		#ifdef ENABLE_INPUT_LOG
 		inputLog_.push(0, 0xFF);
+		#endif
 	}
 
 	void setDmgPaletteColor(int palNum, int colorNum, unsigned long rgb32) {
@@ -73,10 +81,24 @@ public:
 	void selectState(int n) { gb_.selectState(n); }
 	int currentState() const { return gb_.currentState(); }
 	void saveState(PixelBuffer const &fb, std::string const &filepath);
-	void loadState(std::string const &filepath) { gb_.loadState(filepath); inputLog_.restart(gb_); }
+
+	void loadState(std::string const &filepath) {
+		gb_.loadState(filepath);
+		#ifdef ENABLE_INPUT_LOG
+		inputLog_.restart(gb_);
+		#endif
+	}
+
 	QDialog * inputDialog() const { return inputDialog_; }
 	void saveState(PixelBuffer const &fb);
-	void loadState() { gb_.loadState(); inputLog_.restart(gb_); }
+
+	void loadState() {
+		gb_.loadState();
+		#ifdef ENABLE_INPUT_LOG
+		inputLog_.restart(gb_);
+		#endif
+	}
+
 	void tryReset();
 	void setResetParams(unsigned fade, unsigned stall);
 	std::vector<char> inputLogState() const { return inputLog_.initialState; }

--- a/gambatte_qt/src/miscdialog.cpp
+++ b/gambatte_qt/src/miscdialog.cpp
@@ -57,7 +57,7 @@ MiscDialog::MiscDialog(QString const &savepath, QWidget *parent)
 
 	addLayout(topLayout, new QHBoxLayout)->addWidget(pauseOnDialogs_.checkBox());
 	addLayout(topLayout, new QHBoxLayout)->addWidget(pauseOnFocusOut_.checkBox());
-#ifdef ENABLE_TURBO_BUTTONS
+#ifdef ENABLE_FRAMERATE_BUTTONS
 	{
 		QHBoxLayout *hLayout = addLayout(topLayout, new QHBoxLayout);
 		hLayout->addWidget(new QLabel(tr("Base frame rate:")));

--- a/gambatte_qt/src/src.pro
+++ b/gambatte_qt/src/src.pro
@@ -23,7 +23,7 @@ TEMPLATE = app
 CONFIG += warn_on \
     release
 QMAKE_CFLAGS   += -fomit-frame-pointer
-QMAKE_CXXFLAGS += -fomit-frame-pointer -fno-exceptions -fno-rtti -fpermissive
+QMAKE_CXXFLAGS += -fomit-frame-pointer -fno-exceptions -fno-rtti
 TARGET = gambatte_qt
 
 macx:TARGET = "Gambatte Qt"
@@ -31,7 +31,7 @@ DESTDIR = ../bin
 INCLUDEPATH += ../../libgambatte/include
 DEPENDPATH  += ../../libgambatte/include
 QT += widgets gui-private
-LIBS += -L../../libgambatte -l:libgambatte.a -lz
+LIBS += ../../libgambatte/libgambatte.a -lz
 win32 {
 	LIBS += -lole32
 	#RC_FILE = gambatteicon.rc

--- a/libgambatte/src/mem/memptrs.cpp
+++ b/libgambatte/src/mem/memptrs.cpp
@@ -107,7 +107,7 @@ void MemPtrs::reset(unsigned const rombanks, unsigned const rambanks, unsigned c
 	rmem_[0xC] = wmem_[0xC] = wramdata_[0] - mm_wram_begin;
 	rmem_[0xE] = wmem_[0xE] = wramdata_[0] - mm_wram_mirror_begin;
 	setRombank(1);
-	setRambank(0, 0);
+	setRambank(disabled, 0);
 	setVrambank(0);
 	setWrambank(1);
 }

--- a/libgambatte/src/mem/memptrs.h
+++ b/libgambatte/src/mem/memptrs.h
@@ -51,8 +51,7 @@ inline std::size_t wrambank_size() { return 0x1000; }
 
 class MemPtrs {
 public:
-	enum RamFlag { read_en = 1, write_en = 2, rtc_en = 4,
-		disabled = read_en | rtc_en };
+	enum RamFlag { disabled = 0, read_en = 1, write_en = 2, rtc_en = 4 };
 
 	MemPtrs();
 	void reset(unsigned rombanks, unsigned rambanks, unsigned wrambanks);

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -55,7 +55,6 @@ Memory::Memory(Interrupter const &interrupter)
 , oamDmaPos_(-2u & 0xFF)
 , oamDmaStartPos_(0)
 , serialCnt_(0)
-, bus_(0xFF)
 , blanklcd_(false)
 , haltHdmaState_(hdma_low)
 {
@@ -693,8 +692,6 @@ unsigned Memory::nontrivial_read(unsigned const p, unsigned long const cc) {
 
 			if (cart_.rsrambankptr())
 				return cart_.rsrambankptr()[p];
-			else if (cart_.disabledRam())
-				return bus_;
             
 			if (cart_.isHuC3())
 				return cart_.HuC3Read(p, cc);

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -87,17 +87,14 @@ public:
 	}
 
 	unsigned ff_read(unsigned p, unsigned long cc) {
-		bus_ = p < 0x80 ? nontrivial_ff_read(p, cc) : ioamhram_[p + 0x100];
-		return bus_;
+		return p < 0x80 ? nontrivial_ff_read(p, cc) : ioamhram_[p + 0x100];
 	}
 
 	unsigned read(unsigned p, unsigned long cc) {
-		if(biosMode_ && (p < biosSize_ && !(p >= 0x100 && p < 0x200))) {
-			bus_ = readBios(p);
-		} else
-			bus_ = cart_.rmem(p >> 12) ? cart_.rmem(p >> 12)[p] : nontrivial_read(p, cc);
+		if(biosMode_ && (p < biosSize_ && !(p >= 0x100 && p < 0x200)))
+			return readBios(p);
 
-		return bus_;
+		return cart_.rmem(p >> 12) ? cart_.rmem(p >> 12)[p] : nontrivial_read(p, cc);
 	}
 
 	void write(unsigned p, unsigned data, unsigned long cc) {
@@ -192,7 +189,6 @@ private:
 	unsigned char oamDmaPos_;
 	unsigned char oamDmaStartPos_;
 	unsigned char serialCnt_;
-	unsigned char bus_;
 	bool blanklcd_;
 	bool biosMode_;
 	bool agbFlag_;


### PR DESCRIPTION
* Fix regression introduced in 8bf7a08 (commit had a pointer logic issue that broke the testrunner; also the *proper* fix for disabled SRAM reads merits more study, after some further testing)
* Fix various compiler issues
* Disable input log (for the time being)
* Disable framerate-related buttons altogether
* Improve bootrom error message