### PR TITLE
Rename executable, fix SConstruct bug, more cleanup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ $ brew install scons zlib
 
 ### Qt-specific steps
 
-\- Install Xcode Command Line Tools if not already installed:
+\- Install Xcode Command Line Tools (if not already installed; newer Homebrew versions should install them by default):
 ```
 $ xcode-select --install
 ```
@@ -106,9 +106,9 @@ $ xcode-select --install
 ```
 $ brew install qt
 ```
-***\*NOTE:*** After building and creating "Gambatte Qt.app", you can run the following command to create a deployable standalone macOS app, which can be used as a release build that other macOS users can run:
+***\*NOTE:*** After building and creating "Gambatte-Speedrun.app", you can run the following command to create a deployable standalone macOS app, which can be used as a release build that other macOS users can run:
 ```
-$ macdeployqt gambatte_qt/bin/Gambatte\ Qt.app -dmg
+$ macdeployqt gambatte_qt/bin/Gambatte-Speedrun.app -dmg
 ```
 
 ### Testrunner-specific steps

--- a/gambatte_qt/src/fpsselector.cpp
+++ b/gambatte_qt/src/fpsselector.cpp
@@ -46,9 +46,6 @@ FpsSelector::FpsSelector(QWidget *widgetParent)
 {
 	comboBox_->addItem("GB/GBC (" + QString::number(262144.0 / 4389.0) + " fps)",
 	                   QSize(262144, 4389));
-#ifndef ENABLE_FRAMERATE_BUTTONS
-    comboBox_->setHidden(true);
-#endif
 #ifdef ENABLE_FRAMERATE_BUTTONS
 	comboBox_->addItem(tr("Other..."));
 
@@ -58,6 +55,8 @@ FpsSelector::FpsSelector(QWidget *widgetParent)
 	         && loadedValue.width() / loadedValue.height() > 0
 	       ? loadedValue
 	       : value_;
+#else
+	comboBox_->setHidden(true);
 #endif
 	reject();
 	connect(comboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -594,13 +594,7 @@ GambatteMenuHandler::~GambatteMenuHandler() {
 
 void GambatteMenuHandler::setWindowPrefix(QString const &windowPrefix) {
 	QString separator(windowPrefix.isEmpty() ? "" : " - ");
-
-#ifdef GAMBATTE_QT_VERSION_STR
-	QString revision("(" GAMBATTE_QT_VERSION_STR ")");
-#else
-	QString revision("interim");
-#endif
-
+	QString revision("(" GSR_VERSION_STR ")");
 	mw_.setWindowTitle(windowPrefix + separator + "Gambatte-Speedrun " + revision);
 }
 
@@ -821,9 +815,7 @@ void GambatteMenuHandler::about() {
 		&mw_,
 		"About Gambatte-Speedrun",
 		"<h3>Gambatte-Speedrun"
-#ifdef GAMBATTE_QT_VERSION_STR
-		" (" GAMBATTE_QT_VERSION_STR ")"
-#endif
+		" (" GSR_VERSION_STR ")"
 		"</h3>"
 		"<p>"
 			"<b>Homepage:</b> "
@@ -831,7 +823,7 @@ void GambatteMenuHandler::about() {
 				"https://github.com/pokemon-speedrunning/gambatte-speedrun"
 			"</a>"
 		"</p>"
-"<p>"
+		"<p>"
 			"<b>Forked from:</b> "
 			"<a href=\"https://github.com/sinamas/gambatte\">"
 				"https://github.com/sinamas/gambatte"

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -58,11 +58,7 @@ public:
 	void setGameShark(std::string const &codes) { gb_.setGameShark(codes); }
 
 	void reset(unsigned samplesToStall) {
-		std::string revision = "interim";
-	#ifdef GAMBATTE_QT_VERSION_STR
-		revision = GAMBATTE_QT_VERSION_STR;
-	#endif
-		gb_.reset(samplesToStall, revision);
+		gb_.reset(samplesToStall, GSR_VERSION_STR);
 	#ifdef ENABLE_INPUT_LOG
 		inputLog_.push(0, 0xFF);
 	#endif

--- a/gambatte_qt/src/src.pro
+++ b/gambatte_qt/src/src.pro
@@ -24,9 +24,7 @@ CONFIG += warn_on \
     release
 QMAKE_CFLAGS   += -fomit-frame-pointer
 QMAKE_CXXFLAGS += -fomit-frame-pointer -fno-exceptions -fno-rtti
-TARGET = gambatte_qt
 
-macx:TARGET = "Gambatte Qt"
 DESTDIR = ../bin
 INCLUDEPATH += ../../libgambatte/include
 DEPENDPATH  += ../../libgambatte/include
@@ -39,10 +37,19 @@ win32 {
 unix:!macx {
 	QT += x11extras
 }
+
+TARGET = "gambatte_speedrun"
+macx:TARGET = "Gambatte-Speedrun"
+VERSION_STR = interim  # default to interim in case there's an issue getting revision count
+
 exists(../../.git) {
 	MY_GIT_REVNO = $$system(git rev-list HEAD --count)
-	!isEmpty(MY_GIT_REVNO):DEFINES += GAMBATTE_QT_VERSION_STR='\\"r$$MY_GIT_REVNO\\"'
+	!isEmpty(MY_GIT_REVNO) {
+		VERSION_STR = r$$MY_GIT_REVNO
+	}
 }
+
+DEFINES += GSR_VERSION_STR='\\"$$VERSION_STR\\"'
 
 # debug symbols
 #QMAKE_CXXFLAGS_RELEASE += -g

--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -60,10 +60,10 @@ lib = env.Library('gambatte', sourceFiles)
 
 def rev():
 	try:
-		from subprocess import check_output
+		from subprocess import check_output, CalledProcessError
 		stdout = check_output(['git', 'rev-list', 'HEAD', '--count'])
-		return ' -DREVISION=' + stdout.strip()
-	except:
+		return ' -DREVISION=' + stdout.decode().strip()
+	except (OSError, CalledProcessError):
 		return ' -DREVISION=-1'
 
 import sys


### PR DESCRIPTION
This changes the executable name in the qmake build process to:
* gambatte_speedrun.exe (win32)
* Gambatte-Speedrun[.app|.dmg] (macOS)
* gambatte_speedrun (other UNIX)

Additionally, SConstruct for the shared library wasn't working for Python 3; it's now fixed to work in both Python 2 and Python 3.

Otherwise, some more miscellaneous non-functional cleanup of other things I've touched recently.