### PR TITLE
Fix segfaults on resets when revision string is unexpected size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test/testrunner
 *.rc~
 
 gambatte_qt/src/gambatte_qt_plugin_import.cpp
+gambatte_qt/src/gambatte_speedrun_plugin_import.cpp
 gambatte_qt/.qmake.stash
 gambatte_qt/src/platforms.pri
 


### PR DESCRIPTION
This was really only an immediate issue if built from zipped source (i.e. no git repo). The default revision name of "interim" would segfault on hard reset due to expectations in `state_osd_elements.cpp` about the revision string.

This fix will handle longer revision names in general, and put up to the first 8 characters in the on-screen display, while keeping the same look with the current r### format.