### PR TITLE
Adjust defaults

### DIFF
--- a/gambatte_qt/src/framework/src/audioengines/directsoundengine.cpp
+++ b/gambatte_qt/src/framework/src/audioengines/directsoundengine.cpp
@@ -58,7 +58,7 @@ DirectSoundEngine::DirectSoundEngine(HWND hwnd_in)
 , lastpc(0)
 , hwnd(hwnd_in)
 , primaryBuf(false)
-, useGlobalBuf(false)
+, useGlobalBuf(true)
 , blankBuf(true)
 {
 	DirectSoundEnumerateA(enumCallback, this);

--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -165,7 +165,7 @@ WindowSizeMenu::WindowSizeMenu(MainWindow &mw, VideoDialog const &vd)
 	QSize const &size = checkedSize();
 	mw_.setWindowSize(size);
 	if (size.isEmpty())
-		mw_.resize(QSettings().value("mainwindow/size", QSize(160, 144)).toSize());
+		mw_.resize(QSettings().value("mainwindow/size", QSize(320, 288)).toSize());
 }
 
 WindowSizeMenu::~WindowSizeMenu() {


### PR DESCRIPTION
- Default DirectSound global buffer to on for new users (stops audio cutting on focus out)
- Default window size to 2x for new users (more sensible default and should make all menus visible etc)