### PR TITLE
Fix build scripts

### DIFF
--- a/scripts/build_qt.sh
+++ b/scripts/build_qt.sh
@@ -4,4 +4,4 @@ echo "cd libgambatte && scons"
 (cd libgambatte && scons) || exit
 
 echo "cd gambatte_qt && make"
-(cd gambatte_qt && rm -f bin/gambatte_qt.exe && qmake && make)
+(cd gambatte_qt && rm -f bin/gambatte_speedrun.exe && qmake && make)

--- a/scripts/build_qt_only.sh
+++ b/scripts/build_qt_only.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "cd gambatte_qt && make"
-(cd gambatte_qt && rm -f bin/gambatte_qt.exe && qmake && make)
+(cd gambatte_qt && rm -f bin/gambatte_speedrun.exe && qmake && make)


### PR DESCRIPTION
`build_qt.sh` and `build_qt_only.sh` did not respect the new filename for the GSR binary correctly and so were sometimes not building a new binary even after changes were made.