### PR TITLE
Miscellaneous updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Running the hwtests suite requires installing an additional dependency (`libpng`
 ---
 ## Windows
 
-***\*NOTE:*** The instructions below assume you're installing 64-bit MSYS2 and using the 32-bit MinGW toolchain (they do work with other configurations, but the commands won't be exactly the same).
+***\*NOTE:*** The instructions below assume you're installing 64-bit MSYS2 and using the 32-bit MinGW toolchain (they work with other configurations, but the commands won't be exactly the same).
 * Choice of 32-bit vs 64-bit for MSYS2 doesn't really matter; either is fine
 * There's currently no benefit to building a 64-bit version of Gambatte-Speedrun on Windows, so 32-bit is used for the release binaries
 
@@ -27,35 +27,16 @@ Running the hwtests suite requires installing an additional dependency (`libpng`
 
 \- Install [MSYS2](https://www.msys2.org/) by selecting the one-click installer exe for x86_64
 
-\- Initial setup of MSYS2 *(copied from [here](https://github.com/msys2/msys2/wiki/MSYS2-installation#iii-updating-packages))*:
+\- Run MSYS2 shell and update MSYS2 core components and packages *(copied from [here](https://www.msys2.org/wiki/MSYS2-installation/#iii-updating-packages))*:
 ```
-Run MSYS2 shell (Command Prompt). C:\msys64\msys2_shell.cmd
-
-First update MSYS2 core components and packages (if you have not done it yet):
-
 $ pacman -Syuu
 
 Follow the instructions. Repeat this step until it says there are no packages to update.
-
 See the above link if you have an older installation of MSYS2 and/or pacman.
 ```
-\- Prepare MSYS2 for general build development environment *(including essential packages for Qt-related building; copied from [here](https://wiki.qt.io/MSYS2#Prepare_MSYS2_for_Qt_related_build_development_environment))*:
+\- Install MSYS2 packages for general build development environment:
 ```
-Start MSYS2-shell. Run/execute below commands to load MinGW-w64 SEH (64bit/x86_64) posix and Dwarf-2
-(32bit/i686) posix toolchains & related other tools, dependencies & components from MSYS2 REPO
-(MINGW-packages, MSYS2-packages):
-
-$ pacman -S base-devel git mercurial cvs wget p7zip
-$ pacman -S perl ruby python2 mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
-
-Note: the i686 (32bit) toolchain loads into /c/msys64/mingw32/bin (C:\msys64\mingw32\bin) directory
-location, and, x86_64(64bit) toolchain loads into /c/msys64/mingw64/bin (C:\msys64\mingw64\bin)
-directory. Perl, Ruby, Python, OpenSSL etc loads into /c/msys64/usr/bin (C:\msys64\usr\bin)
-directory.
-```
-\- Install the `zlib` package:
-```
-$ pacman -S mingw-w64-i686-zlib
+$ pacman -S base-devel git mingw-w64-i686-zlib mingw-w64-i686-toolchain
 ```
 
 ### Qt-specific steps
@@ -69,9 +50,9 @@ $ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
 ```
 $ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-dbus
 ```
-\- Modify .bash_profile *(in /c/msys64/home/\<USERNAME\>)* by adding this line to the end of the file:
+\- Modify `.bash_profile` to add qt5-static binaries to `PATH`:
 ```
-PATH="/mingw32/qt5-static/bin:${PATH}"
+$ echo 'PATH="/mingw32/qt5-static/bin:${PATH}"' >> ~/.bash_profile
 ```
 
 ### Testrunner-specific steps
@@ -126,7 +107,7 @@ $ brew install libpng
 
 \- Install build dependencies:
 ```
-$ sudo apt install build-essential git scons zlib1g-dev 
+$ sudo apt install build-essential git scons zlib1g-dev
 ```
 
 ### Qt-specific steps

--- a/README
+++ b/README
@@ -21,7 +21,16 @@ Free Software Foundation, Inc.,
 About
 --------------------------------------------------------------------------------
 Gambatte is a work-in-progress, portable, open-source, Game Boy Color emulator,
-and reverse engineering project, written with a wish to preserve something.
+and reverse engineering project, written with a wish to preserve something. The
+development of numerous tests, and their verification on hardware, is as much an
+emphasis as the development of an efficient software implementation.
+
+(Extensive test coverage is seen as necessary to verify the accuracy of an
+efficient software implementation. The preservation aspect of the project is
+emphasised by the development of verified tests to support the development, and
+verification, of accurate implementations. Note that the source code is not
+intended to serve as documentation for the hardware being emulated; efficiency
+and convenience are often emphasised.)
 
 The core emulation code is contained in a separate library backend
 (libgambatte) written in platform-independent C++. There is currently a Qt GUI

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a brief list of the major differences between Gambatte-Speedrun and the
 ---
 ## Building from source
 
-Distributable binaries can be built on Windows using [MSYS2](https://msys2.github.io/) and the qt5-static package, or on macOS using [Homebrew](https://brew.sh/) and the qt package with its `macdeployqt` tool. See [INSTALL.md](INSTALL.md) for detailed information on how to set up the build environment. 
+Distributable binaries can be built on Windows using [MSYS2](https://www.msys2.org/) and the qt5-static package, or on macOS using [Homebrew](https://brew.sh/) and the qt package with its `macdeployqt` tool. See [INSTALL.md](INSTALL.md) for detailed information on how to set up the build environment.
 
 The amount of setup you need to do depends on what parts of the project you are planning to use.
 

--- a/test/qdgbas.py
+++ b/test/qdgbas.py
@@ -8,7 +8,7 @@ class InputError(RuntimeError): pass
 Op = collections.namedtuple('Op', ['string', 'code', 'size', 'assemble'])
 
 def mkrestr(s):
-	return re.sub(r'\s+', r'\s*', re.sub(r'([,)(+])', r' \\\1 ', s))
+	return re.sub(r'\s+', r'\\s*', re.sub(r'([,)(+])', r' \\\1 ', s))
 
 imm8  = r'[0-9a-fA-F][0-9a-fA-F]'
 imm16 = imm8 + imm8
@@ -172,7 +172,7 @@ oplist = makeoplist()
 opregexp = makeopregexp(oplist)
 
 def maptargets(targets, indata, instart, addr):
-	for i in xrange(instart, len(indata)):
+	for i in range(instart, len(indata)):
 		match = opregexp.match(indata[i])
 		if match == None:
 			break
@@ -187,7 +187,7 @@ def maptargets(targets, indata, instart, addr):
 	return i
 
 def astext(outdata, addr, indata, instart, targets):
-	for i in xrange(instart, len(indata)):
+	for i in range(instart, len(indata)):
 		match = opregexp.match(indata[i])
 		if match == None:
 			break
@@ -211,7 +211,7 @@ def astext(outdata, addr, indata, instart, targets):
 
 def asdata(outdata, addr, indata, instart):
 	try:
-		for i in xrange(instart, len(indata)):
+		for i in range(instart, len(indata)):
 			ints = [int(x, 0x10) for x in indata[i].split()]
 			outdata[addr:addr+len(ints)] = ints
 			addr += len(ints)
@@ -240,7 +240,7 @@ def assembleFile(indata):
 	size = 0x8000
 	startpos = 0
 
-	for i in xrange(0, len(indata)):
+	for i in range(0, len(indata)):
 		spl = indata[i].split()
 		if len(spl) > 0 and spl[0] == '.size':
 			size = int(spl[1], 0x10)
@@ -294,11 +294,11 @@ def outFilenameFromInFilename(inname, h143):
 
 def main():
 	for arg in sys.argv[1:]:
-		print 'processing ' + arg
+		print('processing ' + arg)
 		outdata = assembleFile(readDataFromFile(arg))
 		writeDataToFile(outFilenameFromInFilename(arg, outdata[0x143]), outdata)
 	
-	print "\nassembled " + str(len(sys.argv) - 1) + (' files' if len(sys.argv) != 2 else ' file')
+	print("\nassembled " + str(len(sys.argv) - 1) + (' files' if len(sys.argv) != 2 else ' file'))
 
 if __name__ == "__main__":
 	main()

--- a/test/scripts/assemble_tests.sh
+++ b/test/scripts/assemble_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python2 qdgbas.py hwtests/*.asm hwtests/*/*.asm hwtests/*/*/*.asm hwtests/*/*/*/*.asm
+echo hwtests/*.asm hwtests/*/*.asm hwtests/*/*/*.asm hwtests/*/*/*/*.asm | xargs python qdgbas.py


### PR DESCRIPTION
Some changes from a couple months back, before they're forgotten:
- Simplify Windows instructions and update MSYS2 URLs
- Update `qdgbas.py` to work in both Python 2 and 3
- Update `assemble_tests.sh` to use `python` (instead of `python2`) and work with path length issues that could surface on Windows
- Include an upstream change to the README