### PR TITLE
Basic support for MBC30 (rombanks>80 or rambanks>4)

### DIFF
--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -294,12 +294,13 @@ private:
 
 class Mbc3 : public DefaultMbc {
 public:
-	Mbc3(MemPtrs &memptrs, Rtc *const rtc)
+	Mbc3(MemPtrs &memptrs, Rtc *const rtc, bool mbc30)
 	: memptrs_(memptrs)
 	, rtc_(rtc)
 	, rombank_(1)
 	, rambank_(0)
 	, enableRam_(false)
+	, mbc30_(mbc30)
 	{
 	}
 
@@ -318,11 +319,15 @@ public:
 			setRambank();
 			break;
 		case 1:
-			rombank_ = data & 0x7F;
+			rombank_ = data;
+			if(!mbc30_)
+				rombank_ = rombank_ & 0x7F;
 			setRombank();
 			break;
 		case 2:
 			rambank_ = data;
+			if(!mbc30_)
+				rambank_ = rambank_ & 0x03;
 			setRambank();
 			break;
 		case 3:
@@ -353,6 +358,7 @@ private:
 	unsigned char rombank_;
 	unsigned char rambank_;
 	bool enableRam_;
+	bool mbc30_;
 
 	void setRambank() const {
 		unsigned flags = enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : MemPtrs::disabled;
@@ -368,7 +374,7 @@ private:
 	}
 
 	void setRombank() const {
-		memptrs_.setRombank(std::max(rombank_ & (rombanks(memptrs_) - 1), 1u));
+		memptrs_.setRombank(std::max((unsigned) rombank_, 1u) & (rombanks(memptrs_) - 1));
 	}
 };
 
@@ -808,6 +814,8 @@ LoadRes Cartridge::loadROM(std::string const &romfile,
 	rtc_.set(false, 0);
 	huc3_.set(false);
 
+	bool mbc30 = rombanks > 0x80 || rambanks > 0x04;
+
 	rom->rewind();
 	rom->read(reinterpret_cast<char*>(memptrs_.romdata()), filesize / rombank_size() * rombank_size());
 	std::memset(memptrs_.romdata() + filesize / rombank_size() * rombank_size(),
@@ -831,7 +839,7 @@ LoadRes Cartridge::loadROM(std::string const &romfile,
 		break;
 	case type_mbc2: mbc_.reset(new Mbc2(memptrs_)); break;
 	case type_mbc3:
-		mbc_.reset(new Mbc3(memptrs_, hasRtc(memptrs_.romdata()[0x147]) ? &rtc_ : 0));
+		mbc_.reset(new Mbc3(memptrs_, hasRtc(memptrs_.romdata()[0x147]) ? &rtc_ : 0, mbc30));
 		break;
 	case type_mbc5: mbc_.reset(new Mbc5(memptrs_)); break;
 	case type_huc1: mbc_.reset(new HuC1(memptrs_)); break;


### PR DESCRIPTION
Implements #37 but does not do anything regarding the failing MBC3 RTC edge cases mentioned by @entrpntr 's latest comment.