### PR TITLE
Fix crashes when building with Qt 5.11+ on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ test/testrunner
 *.pro~
 *.rc~
 
-gambatte_qt/src/gambatte_qt_plugin_import.cpp
-gambatte_qt/src/gambatte_speedrun_plugin_import.cpp
+*.tmp
+
+gambatte_qt/src/gambatte*plugin_import.cpp
 gambatte_qt/.qmake.stash
 gambatte_qt/src/platforms.pri
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,14 +41,9 @@ $ pacman -S base-devel git mingw-w64-i686-zlib mingw-w64-i686-toolchain
 
 ### Qt-specific steps
 
-\- Acquire and install the Qt 5.6 static library environment *(NOTE: newer versions bundle a lot more into the environment and create much larger builds)*:
+\- Acquire and install the qt5-static library environment:
 ```
-$ curl -O http://repo.msys2.org/mingw/i686/mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
-$ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
-```
-\- Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6:
-```
-$ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-dbus
+$ pacman -S mingw-w64-i686-qt5-static
 ```
 \- Modify `.bash_profile` to add qt5-static binaries to `PATH`:
 ```

--- a/gambatte_qt/src/framework/include/mainwindow.h
+++ b/gambatte_qt/src/framework/include/mainwindow.h
@@ -150,7 +150,7 @@ public:
 
 	/** speed = N, gives N times faster than normal when fastForward is enabled. */
 	void setFastForwardSpeed(int speed);
-	
+
 	void setJoystickThreshold(int threshold);
 
 	/** Sets the video mode that is used for full screen (see toggleFullScreen).
@@ -248,7 +248,6 @@ signals:
 protected:
 	virtual void mouseMoveEvent(QMouseEvent *);
 	virtual void closeEvent(QCloseEvent *);
-	virtual void moveEvent(QMoveEvent *);
 	virtual void resizeEvent(QResizeEvent *);
 	virtual void hideEvent(QHideEvent *);
 	virtual void showEvent(QShowEvent *);
@@ -256,9 +255,6 @@ protected:
 	virtual void focusInEvent(QFocusEvent *);
 	virtual void keyPressEvent(QKeyEvent *);
 	virtual void keyReleaseEvent(QKeyEvent *);
-#ifdef Q_OS_WIN
-	virtual bool nativeEvent(const QByteArray & eventType, void * message, long *result);
-#endif
 
 private:
 	void correctFullScreenGeometry();

--- a/gambatte_qt/src/framework/src/audioengines/directsoundengine.cpp
+++ b/gambatte_qt/src/framework/src/audioengines/directsoundengine.cpp
@@ -32,7 +32,7 @@
 Q_DECLARE_METATYPE(GUID *)
 
 BOOL CALLBACK DirectSoundEngine::enumCallback(LPGUID guid,
-		char const *description, char const */*module*/, LPVOID context) {
+ 		char const *description, char const * /*module*/, LPVOID context) {
 	if (guid) {
 		DirectSoundEngine *thisptr = static_cast<DirectSoundEngine *>(context);
 		thisptr->deviceList.append(*guid);
@@ -186,7 +186,7 @@ long DirectSoundEngine::doInit(long const rate, int const latency, int const vol
 		bufSzDiff = primaryBuf && desiredBufSz < bufSize
 		          ? bufSize - desiredBufSz
 		          : 0;
-		
+
 		{
 			int result;
 			long adjustedVolume;

--- a/gambatte_qt/src/framework/src/dwmcontrol.cpp
+++ b/gambatte_qt/src/framework/src/dwmcontrol.cpp
@@ -170,7 +170,7 @@ bool DwmControl::winEvent(void const *const msg) {
 
 	if (static_cast<MSG const *>(msg)->message == WM_DWMCOMPOSITIONCHANGED) {
 		std::for_each(blitters_.begin(), blitters_.end(),
-		              std::mem_fun(&BlitterWidget::compositionEnabledChange));
+ 		              std::mem_fn(&BlitterWidget::compositionEnabledChange));
 		if (dwmapi_.isCompositionEnabled()) {
 			for (std::vector<BlitterWidget*>::const_iterator it =
 					blitters_.begin(); it != blitters_.end(); ++it) {

--- a/gambatte_qt/src/framework/src/mainwindow.cpp
+++ b/gambatte_qt/src/framework/src/mainwindow.cpp
@@ -206,22 +206,11 @@ void MainWindow::focusInEvent(QFocusEvent *) {
 		doShowFullScreen();
 }
 
-void MainWindow::moveEvent(QMoveEvent *) { w_->moveEvent(this); }
 void MainWindow::resizeEvent(QResizeEvent *) { w_->resizeEvent(this); }
 void MainWindow::mouseMoveEvent(QMouseEvent *) { w_->mouseMoveEvent(); }
 void MainWindow::setPauseOnFocusOut(unsigned bitmask) { w_->setPauseOnFocusOut(bitmask, hasFocus()); }
 void MainWindow::keyPressEvent(QKeyEvent *e) { w_->keyPressEvent(e); }
 void MainWindow::keyReleaseEvent(QKeyEvent *e) { w_->keyReleaseEvent(e); }
-
-#ifdef Q_OS_WIN
-bool MainWindow::nativeEvent(const QByteArray&, void *message, long *) {
-	MSG* msg = reinterpret_cast<MSG*>(message);
-	if (w_->winEvent(msg))
-		emit dwmCompositionChange();
-
-	return false;
-}
-#endif
 
 void MainWindow::doShowFullScreen() {
 	int const screen = QApplication::desktop()->screenNumber(this);

--- a/gambatte_qt/src/framework/src/mediawidget.h
+++ b/gambatte_qt/src/framework/src/mediawidget.h
@@ -46,7 +46,6 @@ public:
 	void hideEvent() { dwmControl_.hideEvent(); }
 	void showEvent(QWidget const *parent) { dwmControl_.showEvent(); fullModeToggler_->setScreen(parent); }
 	void mouseMoveEvent() { blitterContainer_->showCursor(); cursorTimer_->start(); }
-	void moveEvent(QWidget const *parent) { fullModeToggler_->setScreen(parent); }
 	void resizeEvent(QWidget const *parent);
 	void focusOutEvent();
 	void focusInEvent();

--- a/gambatte_qt/src/framework/src/videodialog.cpp
+++ b/gambatte_qt/src/framework/src/videodialog.cpp
@@ -324,9 +324,9 @@ void VideoDialog::accept() {
 	scalingMethodSelector_.accept();
 	sourceSelector_.accept();
 	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::accept));
+ 	              std::mem_fn(&PersistComboBox::accept));
 	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::accept));
+ 	              std::mem_fn(&PersistComboBox::accept));
 	QDialog::accept();
 }
 
@@ -338,9 +338,9 @@ void VideoDialog::reject() {
 	scalingMethodSelector_.reject();
 	sourceSelector_.reject();
 	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::reject));
+ 	              std::mem_fn(&PersistComboBox::reject));
 	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::reject));
+ 	              std::mem_fn(&PersistComboBox::reject));
 	QDialog::reject();
 }
 

--- a/gambatte_qt/src/palettedialog.cpp
+++ b/gambatte_qt/src/palettedialog.cpp
@@ -701,7 +701,7 @@ static void setSchemeList(QStringListModel &model, QString const &savedir, bool 
 	         QDir::Name | QDir::IgnoreCase,
 	         QDir::Files | QDir::Readable);
 	QStringList dirlisting(dir.entryList());
-	std::for_each(dirlisting.begin(), dirlisting.end(), 
+	std::for_each(dirlisting.begin(), dirlisting.end(),
 	              std::bind2nd(std::mem_fun_ref(&QString::chop), 4));
 	model.setStringList(makeStaticStringList(hasGlobal) + dirlisting);
 }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -137,30 +137,30 @@ LoadRes GB::load(std::string const &romfile, unsigned const flags) {
 
 int GB::loadBios(std::string const &biosfile, std::size_t size, unsigned crc) {
 	scoped_ptr<File> const bios(newFileInstance(biosfile));
-	
+
 	if (bios->fail())
 		return -1;
-	
+
 	std::size_t sz = bios->size();
-	
+
 	if (size != 0 && sz != size)
 		return -2;
-	
-	unsigned char newBiosBuffer[sz];
+
+ 	unsigned char* newBiosBuffer = new unsigned char[sz];
 	bios->read((char *)newBiosBuffer, sz);
-	
+
 	if (bios->fail())
 		return -1;
-	
+
 	if (crc != 0) {
-		unsigned char maskedBiosBuffer[sz];
+		unsigned char* maskedBiosBuffer = new unsigned char[sz];
 		std::memcpy(maskedBiosBuffer, newBiosBuffer, sz);
 		maskedBiosBuffer[0xFD] = 0;
 
 		if (crc32(0, maskedBiosBuffer, sz) != crc)
 			return -3;
 	}
-	
+
 	p_->cpu.setBios(newBiosBuffer, sz);
 	return 0;
 }

--- a/libgambatte/src/mem/time.cpp
+++ b/libgambatte/src/mem/time.cpp
@@ -145,7 +145,7 @@ void Time::cyclesFromTime(unsigned long const cc) {
 void Time::timeFromCycles(unsigned long const cc) {
 	update(cc);
 	unsigned long diff = cc - lastCycles_;
-	timeval usec = { 0, (long)(diff / ((rtc_divisor << ds_) / 1000000.0f)) };
+	timeval usec = { 0, (int)(diff / ((rtc_divisor << ds_) / 1000000.0f)) };
 	lastTime_ = now() - usec;
 }
 

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -439,11 +439,11 @@ std::size_t StateSaver::saveState(SaveState const &state,
 		uint_least32_t const *const videoBuf, std::ptrdiff_t const pitch,
 		char *stateBuf, int mode) {
 	std::ostringstream file;
-	
+
 	file.put(0xFF); // make sure original gambatte doesn't load our savestates
 	file.put(SAVE_VERSION);
 	file.put(mode);
-	
+
 	writeSnapShot(file, videoBuf, pitch);
 
 	for (SaverList::const_iterator it = list.begin(); it != list.end(); ++it) {
@@ -465,10 +465,10 @@ bool StateSaver::loadState(SaveState &state,
 	std::istringstream file(std::string(stateBuf, size));
 	if (!file || file.get() != 0xFF)
 		return false;
-	
+
 	if(file.get() != SAVE_VERSION)
 		return false;
-	
+
 	if(checkMode) {
 		if(mode != file.get())
 			return false;
@@ -513,7 +513,7 @@ bool StateSaver::saveState(SaveState const &state,
 		return false;
 
 	std::size_t size = saveState(state, videoBuf, pitch, NULL, mode);
-	char stateBuf[size];
+	char* stateBuf = new char[size];
 
 	saveState(state, videoBuf, pitch, stateBuf, mode);
 	file.write(stateBuf, size);

--- a/test/scripts/clean_tests.sh
+++ b/test/scripts/clean_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm hwtests/*.gb* hwtests/*/*.gb* hwtests/*/*/*.gb* hwtests/*/*/*/*.gb*
+echo hwtests/*.gb* hwtests/*/*.gb* hwtests/*/*/*.gb* hwtests/*/*/*/*.gb* | xargs rm


### PR DESCRIPTION
Fixes #17. 

The main fix was removing `moveEvent` and `nativeEvent`, which seemed to be incorrectly triggered on app startup, and did not appear to serve any useful purpose. Unclear why this did not result in segfaults until Qt 5.11+ for Windows, but versions up to 5.15 all work now with the fix.

Some other changes were made to support an eventual MSVC build.