### PR TITLE
Fix build on arch linux

### DIFF
--- a/gambatte_qt/src/framework/src/syncvar.h
+++ b/gambatte_qt/src/framework/src/syncvar.h
@@ -21,6 +21,7 @@
 
 #include <QMutex>
 #include <QWaitCondition>
+#include <climits>
 
 class SyncVar {
 public:


### PR DESCRIPTION
When building on arch linux I got the following error message:

```
In file included from framework/src/mediaworker.h:25,
                 from framework/src/mediaworker.cpp:19:
framework/src/syncvar.h:33:34: エラー: ‘ULONG_MAX’ was not declared in this scope
   33 |   bool wait(unsigned long time = ULONG_MAX) { return sv.cond_.wait(&sv.mut_, time); }
      |                                  ^~~~~~~~~
framework/src/syncvar.h:24:1: 備考: ‘ULONG_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
   23 | #include <QWaitCondition>
  +++ |+#include <climits>
   24 | 
make[1]: *** [Makefile:1517: mediaworker.o] エラー 1
```

I did what the message said and added `#include <climits>` to `syncvar.h`. After that change I was able to successfully build gambatte-speedrun.