### PR TITLE
Isolated fix for MinGW segfaults on Qt 5.11+ builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ test/testrunner
 *.pro~
 *.rc~
 
-gambatte_qt/src/gambatte_qt_plugin_import.cpp
-gambatte_qt/src/gambatte_speedrun_plugin_import.cpp
+*.tmp
+
+gambatte_qt/src/gambatte*plugin_import.cpp
 gambatte_qt/.qmake.stash
 gambatte_qt/src/platforms.pri
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,18 +41,13 @@ $ pacman -S base-devel git mingw-w64-i686-zlib mingw-w64-i686-toolchain
 
 ### Qt-specific steps
 
-\- Acquire and install the Qt 5.6 static library environment *(NOTE: newer versions bundle a lot more into the environment and create much larger builds)*:
+\- Acquire and install the qt5-static library environment:
 ```
-$ curl -O http://repo.msys2.org/mingw/i686/mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
-$ pacman -U mingw-w64-i686-qt5-static-5.6.2-4-any.pkg.tar.xz
-```
-\- Install Gambatte-Speedrun dependencies that aren't bundled with Qt 5.6:
-```
-$ pacman -S mingw-w64-i686-jasper mingw-w64-i686-libwebp mingw-w64-i686-dbus
+$ pacman -S mingw-w64-i686-qt5-static
 ```
 \- Modify `.bash_profile` to add qt5-static binaries to `PATH`:
 ```
-$ echo 'PATH="/mingw32/qt5-static/bin:${PATH}"' >> ~/.bash_profile
+$ echo 'if [[ "${MSYSTEM}" == "MINGW"* ]]; then PATH="/${MSYSTEM}/qt5-static/bin:${PATH}"; fi' >> ~/.bash_profile
 ```
 
 ### Testrunner-specific steps

--- a/gambatte_qt/src/framework/include/mainwindow.h
+++ b/gambatte_qt/src/framework/include/mainwindow.h
@@ -150,7 +150,7 @@ public:
 
 	/** speed = N, gives N times faster than normal when fastForward is enabled. */
 	void setFastForwardSpeed(int speed);
-	
+
 	void setJoystickThreshold(int threshold);
 
 	/** Sets the video mode that is used for full screen (see toggleFullScreen).
@@ -248,7 +248,6 @@ signals:
 protected:
 	virtual void mouseMoveEvent(QMouseEvent *);
 	virtual void closeEvent(QCloseEvent *);
-	virtual void moveEvent(QMoveEvent *);
 	virtual void resizeEvent(QResizeEvent *);
 	virtual void hideEvent(QHideEvent *);
 	virtual void showEvent(QShowEvent *);
@@ -256,9 +255,6 @@ protected:
 	virtual void focusInEvent(QFocusEvent *);
 	virtual void keyPressEvent(QKeyEvent *);
 	virtual void keyReleaseEvent(QKeyEvent *);
-#ifdef Q_OS_WIN
-	virtual bool nativeEvent(const QByteArray & eventType, void * message, long *result);
-#endif
 
 private:
 	void correctFullScreenGeometry();

--- a/gambatte_qt/src/framework/src/mainwindow.cpp
+++ b/gambatte_qt/src/framework/src/mainwindow.cpp
@@ -206,22 +206,11 @@ void MainWindow::focusInEvent(QFocusEvent *) {
 		doShowFullScreen();
 }
 
-void MainWindow::moveEvent(QMoveEvent *) { w_->moveEvent(this); }
 void MainWindow::resizeEvent(QResizeEvent *) { w_->resizeEvent(this); }
 void MainWindow::mouseMoveEvent(QMouseEvent *) { w_->mouseMoveEvent(); }
 void MainWindow::setPauseOnFocusOut(unsigned bitmask) { w_->setPauseOnFocusOut(bitmask, hasFocus()); }
 void MainWindow::keyPressEvent(QKeyEvent *e) { w_->keyPressEvent(e); }
 void MainWindow::keyReleaseEvent(QKeyEvent *e) { w_->keyReleaseEvent(e); }
-
-#ifdef Q_OS_WIN
-bool MainWindow::nativeEvent(const QByteArray&, void *message, long *) {
-	MSG* msg = reinterpret_cast<MSG*>(message);
-	if (w_->winEvent(msg))
-		emit dwmCompositionChange();
-
-	return false;
-}
-#endif
 
 void MainWindow::doShowFullScreen() {
 	int const screen = QApplication::desktop()->screenNumber(this);

--- a/gambatte_qt/src/framework/src/mediawidget.h
+++ b/gambatte_qt/src/framework/src/mediawidget.h
@@ -46,7 +46,6 @@ public:
 	void hideEvent() { dwmControl_.hideEvent(); }
 	void showEvent(QWidget const *parent) { dwmControl_.showEvent(); fullModeToggler_->setScreen(parent); }
 	void mouseMoveEvent() { blitterContainer_->showCursor(); cursorTimer_->start(); }
-	void moveEvent(QWidget const *parent) { fullModeToggler_->setScreen(parent); }
 	void resizeEvent(QWidget const *parent);
 	void focusOutEvent();
 	void focusInEvent();

--- a/test/scripts/clean_tests.sh
+++ b/test/scripts/clean_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm hwtests/*.gb* hwtests/*/*.gb* hwtests/*/*/*.gb* hwtests/*/*/*/*.gb*
+echo hwtests/*.gb* hwtests/*/*.gb* hwtests/*/*/*.gb* hwtests/*/*/*/*.gb* | xargs rm


### PR DESCRIPTION
Ignores MSVC building and the more complicated machinery in #56 for now (can revisit those if/when relevant again). Includes a few minor changes elsewhere (gitignore/docs/scripts).