### PR TITLE
Add very partial support for exiting stop from a joypad interrupt

### DIFF
--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -525,8 +525,10 @@ void Memory::updateInput() {
 			if (!(ioamhram_[0x100] & 0x20))
 				state &= button_state;
 
-			if (state != 0xF && (ioamhram_[0x100] & 0xF) == 0xF)
+			if (state != 0xF && (ioamhram_[0x100] & 0xF) == 0xF) {
+				stopped_ = false;
 				intreq_.flagIrq(0x10);
+			}
 		}
 	} else if (isSgb())
 		state -= sgb_.getJoypadIndex();


### PR DESCRIPTION
This keeps all of the "make stop really stop" while letting a joypad interrupt request actually allow stop mode to be exited. It doesn't do anything to actually improve the current stop mode implementation (ie screen doesn't black out or anything like it should), but just allows the correct functionality to work as it should.