### PR TITLE
Add Attempt Mode (WIP)

### DIFF
--- a/gambatte_qt/src/gambattemenuhandler.cpp
+++ b/gambatte_qt/src/gambattemenuhandler.cpp
@@ -502,6 +502,12 @@ GambatteMenuHandler::GambatteMenuHandler(MainWindow &mw,
 	trueColorsAction_->setCheckable(true);
 	trueColorsAction_->setChecked(QSettings().value("true-colors", false).toBool());
 	connect(trueColorsAction_, SIGNAL(toggled(bool)), &source, SLOT(setTrueColors(bool)));
+	
+	settingsm->addSeparator();
+	attemptModeAction_ = settingsm->addAction(tr("Attempt &Mode"));
+	attemptModeAction_->setCheckable(true);
+	attemptModeAction_->setChecked(QSettings().value("attempt-mode", true).toBool());
+	connect(attemptModeAction_, SIGNAL(toggled(bool)), &source, SLOT(setAttemptMode(bool)));
 
 	settingsm->addSeparator();
 	fsAct_ = settingsm->addAction(tr("&Full Screen"), this, SLOT(toggleFullScreen()), tr("Ctrl+F"));
@@ -549,6 +555,7 @@ GambatteMenuHandler::GambatteMenuHandler(MainWindow &mw,
 	connect(&mw, SIGNAL(dwmCompositionChange()), this, SLOT(reconsiderSyncFrameRateActionEnable()));
 	connect(this, SIGNAL(romLoaded(bool)), romLoadedActions, SLOT(setEnabled(bool)));
 	connect(this, SIGNAL(romLoaded(bool)), gambattePlatformMenu_.group(), SLOT(setDisabled(bool)));
+	connect(this, SIGNAL(romLoaded(bool)), attemptModeAction_, SLOT(setDisabled(bool)));
 	connect(this, SIGNAL(romLoaded(bool)), stateSlotGroup_->actions().at(0), SLOT(setChecked(bool)));
 
 	mw.setAspectRatio(QSize(160, 144));
@@ -590,6 +597,7 @@ GambatteMenuHandler::~GambatteMenuHandler() {
 	QSettings settings;
 	settings.setValue("rtc-mode", cycleBasedAction_->isChecked());
 	settings.setValue("true-colors", trueColorsAction_->isChecked());
+	settings.setValue("attempt-mode", attemptModeAction_->isChecked());
 }
 
 void GambatteMenuHandler::setWindowPrefix(QString const &windowPrefix) {
@@ -697,8 +705,9 @@ void GambatteMenuHandler::loadFile(QString const &fileName) {
 		//setDmgPaletteColors();
 	}
 
-	source_.setTrueColors(trueColorsAction_->isChecked());
 	source_.setTimeMode(cycleBasedAction_->isChecked());
+	source_.setTrueColors(trueColorsAction_->isChecked());
+	source_.setAttemptMode(attemptModeAction_->isChecked());
 
 	gambatte::PakInfo const &pak = source_.pakInfo();
 	std::cout << romTitle.toStdString() << '\n'

--- a/gambatte_qt/src/gambattemenuhandler.h
+++ b/gambatte_qt/src/gambattemenuhandler.h
@@ -168,6 +168,7 @@ private:
 	QAction *cycleBasedAction_;
 	QAction *realTimeAction_;
 	QAction *trueColorsAction_;
+	QAction *attemptModeAction_;
 	QAction *fsAct_;
 	QMenu *recentMenu_;
 	PaletteDialog *globalPaletteDialog_;

--- a/gambatte_qt/src/gambattesource.h
+++ b/gambatte_qt/src/gambattesource.h
@@ -111,8 +111,9 @@ public:
 	virtual void generateVideoFrame(PixelBuffer const &fb);
 
 public slots:
-	void setTrueColors(bool trueColors) { gb_.setTrueColors(trueColors); }
 	void setTimeMode(bool useCycles) { gb_.setTimeMode(useCycles); }
+	void setTrueColors(bool trueColors) { gb_.setTrueColors(trueColors); }
+	void setAttemptMode(bool attemptMode) { gb_.setAttemptMode(attemptMode); }
 
 signals:
 	void setTurbo(bool on);

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -108,11 +108,14 @@ public:
 	  */
 	void setDmgPaletteColor(int palNum, int colorNum, unsigned long rgb32);
 
-	/** Use GBP color conversion instead of GBC-screen approximation. */
-	void setTrueColors(bool trueColors);
-
 	/** Use cycle-based RTC instead of real-time. */
 	void setTimeMode(bool useCycles);
+
+	/** Use GBP color conversion instead of GBC-screen approximation. */
+	void setTrueColors(bool trueColors);
+	
+	/** Disable unwanted emulator functions for speedrunning attempts. */
+	void setAttemptMode(bool attemptMode) { attemptMode_ = attemptMode; }
 
 	/** Sets the callback used for getting input state. */
 	void setInputGetter(InputGetter *getInput, void *p);
@@ -283,6 +286,8 @@ private:
 
 	GB(GB const &);
 	GB & operator=(GB const &);
+	
+	bool attemptMode_;
 };
 
 }

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -69,8 +69,8 @@ public:
 		mem_.setDmgPaletteColor(palNum, colorNum, rgb32);
 	}
 
-	void setTrueColors(bool trueColors) { mem_.setTrueColors(trueColors); }
 	void setTimeMode(bool useCycles) { mem_.setTimeMode(useCycles, cycleCounter_); }
+	void setTrueColors(bool trueColors) { mem_.setTrueColors(trueColors); }
 	void setRtcDivisorOffset(long const rtcDivisorOffset) { mem_.setRtcDivisorOffset(rtcDivisorOffset); }
 
 	void setGameGenie(std::string const &codes) { mem_.setGameGenie(codes); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -101,7 +101,7 @@ void GB::reset(std::size_t samplesToStall, std::string const &build) {
 			p_->cpu.stall(samplesToStall * 2);
 
 		if (!build.empty())
-			p_->cpu.setOsdElement(newResetElement(build, GB::pakInfo().crc()));
+			p_->cpu.setOsdElement(newResetElement(build, GB::pakInfo().crc(), attemptMode_));
 	}
 }
 
@@ -186,12 +186,12 @@ void GB::setDmgPaletteColor(int palNum, int colorNum, unsigned long rgb32) {
 	p_->cpu.setDmgPaletteColor(palNum, colorNum, rgb32);
 }
 
-void GB::setTrueColors(bool trueColors) {
-	p_->cpu.setTrueColors(trueColors);
-}
-
 void GB::setTimeMode(bool useCycles) {
 	p_->cpu.setTimeMode(useCycles);
+}
+
+void GB::setTrueColors(bool trueColors) {
+	p_->cpu.setTrueColors(trueColors);
 }
 
 bool GB::loadState(std::string const &filepath) {

--- a/libgambatte/src/state_osd_elements.cpp
+++ b/libgambatte/src/state_osd_elements.cpp
@@ -165,7 +165,7 @@ transfer_ptr<OsdElement> newStateSavedOsdElement(unsigned stateNo) {
 	return transfer_ptr<OsdElement>(new ShadedTextOsdElment(text::stateSavedWidth, txt));
 }
 
-transfer_ptr<OsdElement> newResetElement(std::string const &build, unsigned checksum) {
+transfer_ptr<OsdElement> newResetElement(std::string const &build, unsigned checksum, bool attemptMode) {
 	unsigned checksumPart;
 	char txt[sizeof text::reset];
 	std::memcpy(txt, text::reset, sizeof txt);
@@ -199,6 +199,15 @@ transfer_ptr<OsdElement> newResetElement(std::string const &build, unsigned chec
 			txt[idx] = (char) (bitmapfont::A + (checksumPart - 0x0A));
 		}
 	}
+	
+	// Put AM into char array if attempt mode is active
+	// AM -> Attempt Mode
+	if (attemptMode) {
+	int idx = p_len + p_off + 1; // 1 space in between CRC and AM
+	txt[idx] = bitmapfont::A;
+	txt[idx + 1] = bitmapfont::M;
+	}
+		
 
 	return transfer_ptr<OsdElement>(new ShadedTextOsdElment(bitmapfont::getWidth(txt), txt));
 }

--- a/libgambatte/src/state_osd_elements.h
+++ b/libgambatte/src/state_osd_elements.h
@@ -28,7 +28,7 @@ namespace gambatte {
 transfer_ptr<OsdElement> newStateLoadedOsdElement(unsigned stateNo);
 transfer_ptr<OsdElement> newStateSavedOsdElement(unsigned stateNo);
 transfer_ptr<OsdElement> newSaveStateOsdElement(const std::string &fileName, unsigned stateNo);
-transfer_ptr<OsdElement> newResetElement(std::string const &build, unsigned checksum);
+transfer_ptr<OsdElement> newResetElement(std::string const &build, unsigned checksum, bool attemptMode);
 }
 
 #endif


### PR DESCRIPTION
Goals of attempt mode:

- Disable speedup + savestates
- Disable loading pre-existing save files
- Indicators attempt mode is active on hard reset and window border
- Toggleable, but on by default (could potentially be treated like GBP platform for PSR releases, not sure)
- Force Cycle Based RTC (addresses https://github.com/pokemon-speedrunning/gambatte-speedrun/issues/59)
- Force a reset immediately upon loading a ROM (addresses https://github.com/pokemon-speedrunning/gambatte-speedrun/issues/71, https://github.com/pokemon-speedrunning/gambatte-speedrun/issues/49)