### PR TITLE
Fix MBC5 RAM Gate Register

### DIFF
--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -570,7 +570,7 @@ public:
 	virtual void romWrite(unsigned const p, unsigned const data, unsigned long const /*cc*/) {
 		switch (p >> 13 & 3) {
 		case 0:
-			enableRam_ = (data & 0xF) == 0xA;
+			enableRam_ = data == 0xA;
 			setRambank();
 			break;
 		case 1:


### PR DESCRIPTION
Confirmed via ACE payload on Yellow (ran by @TiKevin83), closes https://github.com/pokemon-speedrunning/gambatte-speedrun/issues/87