### PR TITLE
fix LY 0 mode 1 to 2 transition on GBA; add no bios load flag and use as testrunner fallback & have actions use no bios

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: gambatte-speedrun
-
-      - name: Checkout rgbds
-        uses: actions/checkout@v2
-        with:
-          repository: gbdev/rgbds
-          path: rgbds
-      
-      - name: Checkout gb-bootroms
-        uses: actions/checkout@v2
-        with:
-          repository: ISSOtm/gb-bootroms
-          path: gb-bootroms
-          submodules: 'recursive'
-      
-      - name: build rgbds
-        run: "cd rgbds && make && sudo make install"
-
-      - name: build bootROMs
-        run: "cd gb-bootroms && make && cp ./bin/dmg.bin ../gambatte-speedrun/test/bios.gb && cp ./bin/cgb.bin ../gambatte-speedrun/test/bios.gbc"
       
       - name: Assemble TestROMs
         run: "cd gambatte-speedrun/test && sh scripts/assemble_tests.sh"

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -42,7 +42,8 @@ public:
 		                            MBCs disguised as MBC1. */
 		SGB_MODE         = 8,  /**< Treat the ROM as having SGB support regardless of
 		                            what its header advertises. */
-		READONLY_SAV     = 16  /**< Prevent implicit saveSavedata calls for the ROM. */
+		READONLY_SAV     = 16, /**< Prevent implicit saveSavedata calls for the ROM. */
+		NO_BIOS          = 32  /**< Use heuristics to boot without a BIOS */
 	};
 
 	/**

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -43,7 +43,7 @@ public:
 		SGB_MODE         = 8,  /**< Treat the ROM as having SGB support regardless of
 		                            what its header advertises. */
 		READONLY_SAV     = 16, /**< Prevent implicit saveSavedata calls for the ROM. */
-		NO_BIOS          = 32  /**< Use heuristics to boot without a BIOS */
+		NO_BIOS          = 32  /**< Use heuristics to boot without a BIOS. */
 	};
 
 	/**

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -95,6 +95,9 @@ void GB::reset(std::size_t samplesToStall, std::string const &build) {
 		p_->cpu.setStatePtrs(state);
 		p_->cpu.saveState(state);
 		setInitState(state, p_->loadflags & CGB_MODE, p_->loadflags & SGB_MODE);
+		if (p_->loadflags & NO_BIOS)
+			setPostBiosState(state, p_->loadflags & CGB_MODE, p_->loadflags & GBA_FLAG);
+
 		p_->cpu.loadState(state);
 
 		if (samplesToStall > 0)
@@ -128,6 +131,9 @@ LoadRes GB::load(std::string const &romfile, unsigned const flags) {
 		p_->cpu.setStatePtrs(state);
 		p_->loadflags = flags;
 		setInitState(state, flags & CGB_MODE, flags & SGB_MODE);
+		if (flags & NO_BIOS)
+			setPostBiosState(state, flags & CGB_MODE, flags & GBA_FLAG);
+
 		setInitStateCart(state);
 		p_->cpu.loadState(state);
 		p_->cpu.loadSavedata();

--- a/libgambatte/src/initstate.h
+++ b/libgambatte/src/initstate.h
@@ -23,6 +23,7 @@ namespace gambatte {
 
 void setInitState(struct SaveState &state, bool cgb, bool sgb);
 void setInitStateCart(struct SaveState &state);
+void setPostBiosState(struct SaveState &state, bool cgb, bool agb);
 
 }
 

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -1228,12 +1228,12 @@ LoadRes Memory::loadROM(std::string const &romfile, unsigned const flags) {
 	if (LoadRes const fail = cart_.loadROM(romfile, cgbMode, multicartCompat))
 		return fail;
 
-	psg_.init(cart_.isCgb());
-	lcd_.reset(ioamhram_, cart_.vramdata(), cart_.isCgb());
-	interrupter_.setGameShark(std::string());
-
 	agbFlag_ = flags & GB::LoadFlag::GBA_FLAG;
 	gbIsSgb_ = flags & GB::LoadFlag::SGB_MODE;
+
+	psg_.init(cart_.isCgb());
+	lcd_.reset(ioamhram_, cart_.vramdata(), cart_.isCgb(), agbFlag_);
+	interrupter_.setGameShark(std::string());
 
 	return LOADRES_OK;
 }

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -37,6 +37,7 @@ struct SaveState {
 		friend class SaverList;
 		friend void setInitState(SaveState &, bool, bool);
 		friend void setInitStateCart(SaveState &);
+		friend void setPostBiosState(SaveState &, bool, bool);
 
 	private:
 		T *ptr;

--- a/libgambatte/src/video.cpp
+++ b/libgambatte/src/video.cpp
@@ -133,12 +133,12 @@ LCD::LCD(unsigned char const *oamram, unsigned char const *vram,
 	std::memset( bgpData_, 0, sizeof  bgpData_);
 	std::memset(objpData_, 0, sizeof objpData_);
 
-	reset(oamram, vram, false);
+	reset(oamram, vram, false, false);
 	setVideoBuffer(0, lcd_hres);
 }
 
-void LCD::reset(unsigned char const *oamram, unsigned char const *vram, bool cgb) {
-	ppu_.reset(oamram, vram, cgb);
+void LCD::reset(unsigned char const *oamram, unsigned char const *vram, bool cgb, bool agb) {
+	ppu_.reset(oamram, vram, cgb, agb);
 	lycIrq_.setCgb(cgb);
 	refreshPalettes();
 }
@@ -782,7 +782,7 @@ unsigned LCD::getStat(unsigned const lycReg, unsigned long const cc) {
 		long const frameCycles = 1l * ly * lcd_cycles_per_line + lineCycles;
 		if (frameCycles >= lcd_vres * lcd_cycles_per_line - 3 && frameCycles < lcd_cycles_per_frame - 3) {
 			if (frameCycles >= lcd_vres * lcd_cycles_per_line - 2
-					&& frameCycles < lcd_cycles_per_frame - 4 + isDoubleSpeed()) {
+					&& frameCycles < lcd_cycles_per_frame - 4 + isDoubleSpeed() + (ly == lcd_lines_per_frame - 1 && isAgb())) {
 				stat = 1;
 			}
 		} else if (lineCycles < 77 || lineCycles >= lcd_cycles_per_line - 3) {

--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -50,7 +50,7 @@ class LCD {
 public:
 	LCD(unsigned char const *oamram, unsigned char const *vram,
 	    VideoInterruptRequester memEventRequester);
-	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb);
+	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb, bool agb);
 	void setCgbDmg(bool enabled) { ppu_.setCgbDmg(enabled); }
 	void setStatePtrs(SaveState &state);
 	void saveState(SaveState &state) const;
@@ -146,6 +146,7 @@ public:
 	bool hdmaIsEnabled() const { return eventTimes_(memevent_hdma) != disabled_time; }
 	void update(unsigned long cycleCounter);
 	bool isCgb() const { return ppu_.cgb(); }
+	bool isAgb() const { return ppu_.agb(); }
 	bool isCgbDmg() const { return ppu_.cgbDmg(); }
 	bool isDoubleSpeed() const { return ppu_.lyCounter().isDoubleSpeed(); }
 	bool isTrueColors() const { return ppu_.trueColors(); }

--- a/libgambatte/src/video/ppu.cpp
+++ b/libgambatte/src/video/ppu.cpp
@@ -1784,9 +1784,10 @@ void PPU::loadState(SaveState const &ss, unsigned char const *const oamram) {
 	}
 }
 
-void PPU::reset(unsigned char const *oamram, unsigned char const *vram, bool cgb) {
+void PPU::reset(unsigned char const *oamram, unsigned char const *vram, bool cgb, bool agb) {
 	p_.vram = vram;
 	p_.cgb = cgb;
+	p_.agb = agb;
 	p_.cgbDmg = false;
 	p_.spriteMapper.reset(oamram, cgb);
 }

--- a/libgambatte/src/video/ppu.h
+++ b/libgambatte/src/video/ppu.h
@@ -97,6 +97,7 @@ struct PPUPriv {
 	unsigned char endx;
 
 	bool cgb;
+	bool agb;
 	bool cgbDmg;
 	bool weMaster;
 	bool trueColors;
@@ -114,6 +115,7 @@ public:
 
 	unsigned long * bgPalette() { return p_.bgPalette; }
 	bool cgb() const { return p_.cgb; }
+	bool agb() const { return p_.agb; }
 	bool cgbDmg() const { return p_.cgbDmg; }
 	bool trueColors() const { return p_.trueColors; }
 	void doLyCountEvent() { p_.lyCounter.doEvent(); }
@@ -132,7 +134,7 @@ public:
 	void oamChange(unsigned long cc) { p_.spriteMapper.oamChange(cc); }
 	void oamChange(unsigned char const *oamram, unsigned long cc) { p_.spriteMapper.oamChange(oamram, cc); }
 	unsigned long predictedNextXposTime(unsigned xpos) const;
-	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb);
+	void reset(unsigned char const *oamram, unsigned char const *vram, bool cgb, bool agb);
 	void setCgbDmg(bool enabled) { p_.cgbDmg = enabled; }
 	void resetCc(unsigned long oldCc, unsigned long newCc);
 	void saveState(SaveState &ss) const;


### PR DESCRIPTION
Closes https://github.com/pokemon-speedrunning/gambatte-speedrun/issues/91