### PR TITLE
Misc Improvement for Testrunner Performance w/o BIOS

### DIFF
--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -313,8 +313,12 @@ static void runTestRom(
 
 	std::putchar(cgb ? (agb ? 'a' : 'c') : 'd');
 	std::fflush(stdout);
+	
+	long biosLength = cgb ? 186 : 334;
+	if (flags & gambatte::GB::LoadFlag::NO_BIOS)
+		biosLength = 0;
 
-	long samplesLeft = samples_per_frame * ((cgb ? 186 : 334) + 15);
+	long samplesLeft = samples_per_frame * (biosLength + 15);
 
 	while (samplesLeft >= 0) {
 		std::size_t samples = samples_per_frame;


### PR DESCRIPTION
The testrunner doesn't need to run as long without BIOS enabled, this should speed up the process quite a bit.

EDIT: Going off Github actions this shortens testrunner length by 4 times.