### PR TITLE
Replace std::bindX and std::mem_fun with lambdas.

### DIFF
--- a/gambatte_qt/src/framework/src/dwmcontrol.cpp
+++ b/gambatte_qt/src/framework/src/dwmcontrol.cpp
@@ -23,7 +23,6 @@
 
 #include <windows.h>
 #include <algorithm>
-#include <functional>
 #include <QWindow>
 #include <QGuiApplication>
 #include <qpa/qplatformnativeinterface.h>
@@ -169,8 +168,12 @@ bool DwmControl::winEvent(void const *const msg) {
 	//enum { WM_DWMCOMPOSITIONCHANGED = 0x031E };
 
 	if (static_cast<MSG const *>(msg)->message == WM_DWMCOMPOSITIONCHANGED) {
+		static auto compositionEnabledChangeFunc =
+				[](BlitterWidget &widget) {
+					widget.compositionEnabledChange();
+				};
 		std::for_each(blitters_.begin(), blitters_.end(),
-		              std::mem_fun(&BlitterWidget::compositionEnabledChange));
+									compositionEnabledChangeFunc);
 		if (dwmapi_.isCompositionEnabled()) {
 			for (std::vector<BlitterWidget*>::const_iterator it =
 					blitters_.begin(); it != blitters_.end(); ++it) {

--- a/gambatte_qt/src/framework/src/videodialog.cpp
+++ b/gambatte_qt/src/framework/src/videodialog.cpp
@@ -27,7 +27,6 @@
 #include <QRadioButton>
 #include <QSettings>
 #include <QVBoxLayout>
-#include <functional>
 
 VideoDialog::ScalingMethodSelector::ScalingMethodSelector(QWidget *parent)
 : unrestrictedScalingButton_(new QRadioButton(QObject::tr("None"), parent))
@@ -323,10 +322,9 @@ void VideoDialog::accept() {
 	engineSelector_.accept();
 	scalingMethodSelector_.accept();
 	sourceSelector_.accept();
-	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::accept));
-	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::accept));
+	static auto acceptFunc = [](PersistComboBox *const box) { box->accept(); };
+	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(), acceptFunc);
+	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(), acceptFunc);
 	QDialog::accept();
 }
 
@@ -337,10 +335,9 @@ void VideoDialog::reject() {
 	engineSelector_.reject();
 	scalingMethodSelector_.reject();
 	sourceSelector_.reject();
-	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::reject));
-	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(),
-	              std::mem_fun(&PersistComboBox::reject));
+	static auto rejectFunc = [](PersistComboBox *const box) { box->reject(); };
+	std::for_each(fullResSelectors_.begin(), fullResSelectors_.end(), rejectFunc);
+	std::for_each(fullHzSelectors_.begin(), fullHzSelectors_.end(), rejectFunc);
 	QDialog::reject();
 }
 

--- a/gambatte_qt/src/palettedialog.cpp
+++ b/gambatte_qt/src/palettedialog.cpp
@@ -40,7 +40,6 @@
 #include <QDrag>
 #include <algorithm>
 #include <cstring>
-#include <functional>
 
 namespace {
 
@@ -701,8 +700,8 @@ static void setSchemeList(QStringListModel &model, QString const &savedir, bool 
 	         QDir::Name | QDir::IgnoreCase,
 	         QDir::Files | QDir::Readable);
 	QStringList dirlisting(dir.entryList());
-	std::for_each(dirlisting.begin(), dirlisting.end(), 
-	              std::bind2nd(std::mem_fun_ref(&QString::chop), 4));
+	static auto chopFunc = [](QString &str) { str.chop(4); };
+	std::for_each(dirlisting.begin(), dirlisting.end(), chopFunc);
 	model.setStringList(makeStaticStringList(hasGlobal) + dirlisting);
 }
 

--- a/gambatte_qt/src/src.pro
+++ b/gambatte_qt/src/src.pro
@@ -21,7 +21,8 @@ HEADERS += $$COMMONPATH/videolink/*.h \
            $$COMMONPATH/videolink/vfilters/*.h
 TEMPLATE = app
 CONFIG += warn_on \
-    release
+    release \
+    c++11
 QMAKE_CFLAGS   += -fomit-frame-pointer
 QMAKE_CXXFLAGS += -fomit-frame-pointer -fno-exceptions -fno-rtti
 


### PR DESCRIPTION
Also see https://github.com/pokemon-speedrunning/gambatte-core/issues/18

---

`std::bind1st`, `std::bind2nd`, and `std::mem_fun` were deprecated in C++11 and removed in C++17.

GCC is the only compiler that allows using these functions regardless of the standard. Clang (both LLVM, and Apple Clang) and MSVC will error out on standard >=C++17. This is currently mainly an issue for LLVM Clang as starting LLVM 16, Clang defaults to C++17 and no standard used to be set in qmake.

This PR addresses this issue by using C++11 lambdas. This typically offers better performances compared to the alternative `std::bind` and `std::mem_fn`, and better extensibility if more methods need to be called in the same loop.

<details>

<summary>Benchmark for reference</summary>

Here are some speed results for calling the same member function 1'000'000'000 times:
```
Took 3.79699s to run 1000000000 steps with lambda
Took 4.25883s to run 1000000000 steps with mem_fn // Only for object pointers, no equivalent to mem_fun_ref
Took 13.6731s to run 1000000000 steps with bind
Took 16.3081s to run 1000000000 steps with mem_fn+bind
```

</details>